### PR TITLE
Remove Epoch Tweaking

### DIFF
--- a/protocol_explanation.md
+++ b/protocol_explanation.md
@@ -386,44 +386,6 @@ With KVAC, this process is simplified:
    M_{a'} \gets M_a + o \cdot G_\text{amount}
 ```
 
-### Epoch Tweaking of Base Keys
-
-Epoch changes help Mint runners maintain reasonably sized databases. When a epoch change occurs,
-the Mint creates new keys for each supported unit and advertises them on its `info` endpoints.
-From that moment on, the Mint will only issue `MAC`s with those newer keys, while still accepting `MAC`s issued with keys from a previous iteration.
-This comes at a slight cost for the user, which has to re-enstablish trust whenever polling for the newest keysets.
-
-
-Epoch tweaking makes it possible for clients to autonomously calculate the Mint's public keys for the next iteration by simply tweaking a **base** key.
-
-Derived Private Key (Mint) for epoch number $i$:
-[code](https://github.com/lollerfirst/cashu-kvac/blob/0f175081bcc52a6da198c6ab54ede65691858d78/src/models.rs#L83)
-```math
-\displaylines{
-\begin{aligned}
-e &\leftarrow \text{Hash}(Cw \mathbin\Vert I \mathbin\Vert \text{epoch})\\
-w^i &= w + e\\
-w'^i &= w' + e\\
-x_0^i &= x_0 + e\\
-x_1^i &= x_1 + e\\
-y_a^i &= y_a + e\\
-y_s^i &= y_s + e
-\end{aligned}
-}
-```
-
-Derived Public Key (Client) for epoch number $i$:
-[code](https://github.com/lollerfirst/cashu-kvac/blob/0f175081bcc52a6da198c6ab54ede65691858d78/src/models.rs#L19):
-```math
-\displaylines{
-\begin{aligned}
-e &\leftarrow \text{Hash}(C_w \mathbin\Vert I \mathbin\Vert \text{epoch})\\
-I^i &= I - (e\cdot G_{x_0} + e\cdot G_{x_1} + e\cdot G_\text{zamount} + e\cdot G_\text{zscript})\\
-C_w^i &= C_w + (e\cdot W + e\cdot W')
-\end{aligned}
-}
-```
-
 ---
 
 ### `CashuTranscript`

--- a/src/models.rs
+++ b/src/models.rs
@@ -15,24 +15,6 @@ pub struct MintPublicKey {
 }
 
 #[allow(non_snake_case)]
-impl MintPublicKey {
-    pub fn tweak_epoch(self, epoch: u64) -> MintPublicKey {
-        let mut preimage_e = self.Cw.to_bytes();
-        preimage_e.extend(self.I.to_bytes());
-        preimage_e.extend(epoch.to_be_bytes());
-        let hash_e = Sha256Hash::hash(&preimage_e).to_byte_array();
-        let e = Scalar::new(&hash_e);
-        let Cw = self.Cw + &(GENERATORS.W.clone() * &e) + &(GENERATORS.W_.clone() * &e);
-        let I = self.I
-            - &(GENERATORS.X0.clone() * &e
-                + &(GENERATORS.X1.clone() * &e)
-                + &(GENERATORS.Gz_attribute.clone() * &e)
-                + &(GENERATORS.Gz_script.clone() * &e));
-        MintPublicKey { Cw, I }
-    }
-}
-
-#[allow(non_snake_case)]
 #[derive(Clone, Serialize, Hash, Deserialize, Debug, Eq, PartialEq)]
 pub struct MintPrivateKey {
     pub w: Scalar,
@@ -78,23 +60,6 @@ impl MintPrivateKey {
             self.ya.clone(),
             self.ys.clone(),
         ]
-    }
-
-    pub fn tweak_epoch(self, epoch: u64) -> MintPrivateKey {
-        let mut preimage_e = self.public_key.Cw.to_bytes();
-        preimage_e.extend(self.public_key.I.to_bytes());
-        preimage_e.extend(epoch.to_be_bytes());
-        let hash_e = Sha256Hash::hash(&preimage_e).to_byte_array();
-        let e = Scalar::new(&hash_e);
-        MintPrivateKey {
-            w: self.w + &e,
-            w_: self.w_ + &e,
-            x0: self.x0 + &e,
-            x1: self.x1 + &e,
-            ya: self.ya + &e,
-            ys: self.ys + &e,
-            public_key: self.public_key.tweak_epoch(epoch),
-        }
     }
 }
 


### PR DESCRIPTION
Epoch tweaking made it possible to forge MACs across different epochs. 