### PR TITLE
Remove `is_zero` property from Scalar and GroupElement

### DIFF
--- a/src/bulletproof.rs
+++ b/src/bulletproof.rs
@@ -273,10 +273,7 @@ pub struct BulletProof {
 
 #[allow(non_snake_case)]
 impl BulletProof {
-    pub fn new(
-        transcript: &mut CashuTranscript,
-        attributes: &[AmountAttribute],
-    ) -> Self {
+    pub fn new(transcript: &mut CashuTranscript, attributes: &[AmountAttribute]) -> Self {
         // Domain separation
         transcript.domain_sep(b"Bulletproof_Statement_");
 
@@ -683,10 +680,8 @@ mod tests {
         let mut cli_tscr = CashuTranscript::new();
         let mut mint_tscr = CashuTranscript::new();
 
-        let attributes: Vec<AmountAttribute> = vec![
-            AmountAttribute::new(0, None),
-            AmountAttribute::new(0, None),
-        ];
+        let attributes: Vec<AmountAttribute> =
+            vec![AmountAttribute::new(0, None), AmountAttribute::new(0, None)];
         let mut attribute_commitments = Vec::new();
         for attr in attributes.iter() {
             attribute_commitments.push((attr.commitment().clone(), None));

--- a/src/kvac.rs
+++ b/src/kvac.rs
@@ -528,7 +528,7 @@ impl RangeProof {
     ) -> bool {
         match proof {
             RangeZKP::BULLETPROOF(bulletproof) => {
-                bulletproof.verify(transcript, &attribute_commitments)
+                bulletproof.verify(transcript, attribute_commitments)
             }
         }
     }

--- a/src/kvac.rs
+++ b/src/kvac.rs
@@ -2,7 +2,8 @@ use crate::bulletproof::BulletProof;
 use crate::errors::Error;
 use crate::generators::{hash_to_curve, GENERATORS};
 use crate::models::{
-    AmountAttribute, Coin, Equation, MintPrivateKey, MintPublicKey, RandomizedCoin, RangeZKP, ScriptAttribute, Statement, MAC, ZKP
+    AmountAttribute, Coin, Equation, MintPrivateKey, MintPublicKey, RandomizedCoin, RangeZKP,
+    ScriptAttribute, Statement, MAC, ZKP,
 };
 use crate::secp::{GroupElement, Scalar, GROUP_ELEMENT_ZERO, SCALAR_ZERO};
 use crate::transcript::CashuTranscript;
@@ -526,7 +527,9 @@ impl RangeProof {
         proof: RangeZKP,
     ) -> bool {
         match proof {
-            RangeZKP::BULLETPROOF(bulletproof) => bulletproof.verify(transcript, &attribute_commitments),
+            RangeZKP::BULLETPROOF(bulletproof) => {
+                bulletproof.verify(transcript, &attribute_commitments)
+            }
         }
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -176,9 +176,9 @@ impl MAC {
             Ms = GroupElement::new(&GROUP_ELEMENT_ZERO);
         }
         let V = GENERATORS.W.clone() * &privkey.w
-            + &(U.clone() * &privkey.x0
-                + &(U.clone() * &(t.clone() * &privkey.x1)
-                    + &(Ma * &(privkey.ya) + &(Ms * &(privkey.ys)))));
+            + &(U.clone() * &privkey.x0)
+            + &(U.clone() * &(t.clone() * &privkey.x1))
+            + &(Ma * &(privkey.ya) + &(Ms * &(privkey.ys)));
         Ok(MAC { t, V })
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,5 +1,8 @@
 use crate::{
-    bulletproof::BulletProof, errors::Error, generators::{hash_to_curve, GENERATORS}, secp::{GroupElement, Scalar, GROUP_ELEMENT_ZERO}
+    bulletproof::BulletProof,
+    errors::Error,
+    generators::{hash_to_curve, GENERATORS},
+    secp::{GroupElement, Scalar, GROUP_ELEMENT_ZERO},
 };
 use bitcoin::hashes::sha256::Hash as Sha256Hash;
 use bitcoin::hashes::Hash;

--- a/src/secp.rs
+++ b/src/secp.rs
@@ -81,22 +81,16 @@ fn modinv(m: &Integer, x: &Integer) -> Integer {
 impl Scalar {
     pub fn new(data: &[u8]) -> Self {
         if *data == SCALAR_ZERO {
-            Scalar {
-                inner: None,
-            }
+            Scalar { inner: None }
         } else {
             let inner = SecretKey::from_slice(data).expect("Could not instantiate Scalar");
-            Scalar {
-                inner: Some(inner),
-            }
+            Scalar { inner: Some(inner) }
         }
     }
 
     pub fn random() -> Self {
         let inner = SecretKey::new(&mut rand::thread_rng());
-        Scalar {
-            inner: Some(inner),
-        }
+        Scalar { inner: Some(inner) }
     }
 
     pub fn tweak_mul(&mut self, other: &Scalar) -> &Self {
@@ -159,9 +153,7 @@ impl Scalar {
             }
             vec.reverse();
             let inner = SecretKey::from_slice(&vec).expect("Could not instantiate Scalar");
-            Scalar {
-                inner: Some(inner),
-            }
+            Scalar { inner: Some(inner) }
         }
     }
 
@@ -181,14 +173,10 @@ impl Scalar {
 impl GroupElement {
     pub fn new(data: &[u8]) -> Self {
         if *data == GROUP_ELEMENT_ZERO {
-            GroupElement {
-                inner: None,
-            }
+            GroupElement { inner: None }
         } else {
             let inner = PublicKey::from_slice(data).expect("Cannot create GroupElement");
-            GroupElement {
-                inner: Some(inner),
-            }
+            GroupElement { inner: Some(inner) }
         }
     }
 
@@ -437,9 +425,7 @@ impl<'de> Deserialize<'de> for Scalar {
 
 impl Default for Scalar {
     fn default() -> Self {
-        Scalar {
-            inner: None,
-        }
+        Scalar { inner: None }
     }
 }
 
@@ -588,9 +574,7 @@ impl<'de> Deserialize<'de> for GroupElement {
 
 impl Default for GroupElement {
     fn default() -> Self {
-        GroupElement {
-            inner: None,
-        }
+        GroupElement { inner: None }
     }
 }
 
@@ -864,7 +848,7 @@ mod tests {
     fn test_ge_amount_tweak() {
         let mut ge = GENERATORS.G_amount.clone();
         ge = ge * &Scalar::from(2);
-        
+
         let tweak = 4 as u64;
 
         ge.tweak(TweakKind::AMOUNT, tweak);


### PR DESCRIPTION
Replaced by `is_none` checks on the inner element.