### PR TITLE
Add More Docs to Structs and Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,16 @@ Definitions and Protocol explaination (WIP): [HERE](protocol_explanation.md)
 ### Extras
 * [Deterministic Recovery](deterministic_recovery.md)
 * Server/Mint can tweak the amounts encoded in the attributes: $M_a' = M_a + \delta G_\text{amount}$
-* We are using $r$ as both the randomizing factor and the blinding factor:
+* Using the $r$ blinding factor in Pedersen Commitments as the randomizing factor as well:
   - different generators with unknown discrete log between them guarantees hiding.
   - Benefit: no $\pi_\text{serial}$ because not needed anymore.
-  - $C_a$ (Randomized Amount Commitment) is chosen as the nullifier
+  - $C_a$ (Randomized Amount Commitment) is chosen to be the nullifier.
 
 ### Range proofs
-Implementations:
-* [BULLETPROOFS](https://eprint.iacr.org/2017/1066.pdf), from which the next logical improvement will be  [BULLETPROOFS++](https://eprint.iacr.org/2022/510.pdf) arithmetic circuits.
-* *(Not yet implemented)* [SHARP](https://eprint.iacr.org/2022/1153.pdf) which would improve creation/verification time tenfold. There are some different flavours of sharp, some of which make use of hidden order groups.
+Variations:
+* [x] [BULLETPROOFS](https://eprint.iacr.org/2017/1066.pdf)
+* [] [BULLETPROOFS++](https://eprint.iacr.org/2022/510.pdf) aritmetic circuits
+* [] [SHARP](https://eprint.iacr.org/2022/1153.pdf) which would improve creation/verification time tenfold. There are some different flavours of sharp, some of which make use of hidden order groups.
+
+### Transcript
+Every Zero-Knowledge proof uses a dedicated transcript defined in `transcript.rs` and tweaked by a domain separation byte-string for the various statements that need to be proven.

--- a/README.md
+++ b/README.md
@@ -124,4 +124,6 @@ Definitions and Protocol explaination (WIP): [HERE](protocol_explanation.md)
   - $C_a$ (Randomized Amount Commitment) is chosen as the nullifier
 
 ### Range proofs
-Range proofs are implemented as [BULLETPROOFS](https://eprint.iacr.org/2017/1066.pdf), from which the next logical improvement will be  [BULLETPROOFS++](https://eprint.iacr.org/2022/510.pdf) arithmetic circuits.
+Implementations:
+* [BULLETPROOFS](https://eprint.iacr.org/2017/1066.pdf), from which the next logical improvement will be  [BULLETPROOFS++](https://eprint.iacr.org/2022/510.pdf) arithmetic circuits.
+* *(Not yet implemented)* [SHARP](https://eprint.iacr.org/2022/1153.pdf) which would improve creation/verification time tenfold. There are some different flavours of sharp, some of which make use of hidden order groups.

--- a/README.md
+++ b/README.md
@@ -124,10 +124,12 @@ Definitions and Protocol explaination (WIP): [HERE](protocol_explanation.md)
   - $C_a$ (Randomized Amount Commitment) is chosen to be the nullifier.
 
 ### Range proofs
+
 Variations:
+
 * [x] [BULLETPROOFS](https://eprint.iacr.org/2017/1066.pdf)
-* [] [BULLETPROOFS++](https://eprint.iacr.org/2022/510.pdf) aritmetic circuits
-* [] [SHARP](https://eprint.iacr.org/2022/1153.pdf) which would improve creation/verification time tenfold. There are some different flavours of sharp, some of which make use of hidden order groups.
+* [ ] [BULLETPROOFS++](https://eprint.iacr.org/2022/510.pdf) aritmetic circuits
+* [ ] [SHARP](https://eprint.iacr.org/2022/1153.pdf) which would improve creation/verification time tenfold. There are some different flavours of sharp, some of which make use of hidden order groups.
 
 ### Transcript
 Every Zero-Knowledge proof uses a dedicated transcript defined in `transcript.rs` and tweaked by a domain separation byte-string for the various statements that need to be proven.

--- a/benches/proofs_bench.rs
+++ b/benches/proofs_bench.rs
@@ -344,7 +344,7 @@ fn bench_range_proof_verification(bencher: &mut Bencher) {
     let proof = BulletProof::new(&mut cli_tscr, &attributes);
     let mut attribute_commitments = Vec::new();
     for attr in attributes.iter() {
-        attribute_commitments.push((attr.commitment().clone(), None));
+        attribute_commitments.push(attr.commitment().clone());
     }
     bencher.iter(|| proof.clone().verify(&mut mint_tscr, &attribute_commitments));
 }

--- a/src/bulletproof.rs
+++ b/src/bulletproof.rs
@@ -518,7 +518,7 @@ impl BulletProof {
 
         // Append amount commitments to the transcript
         for V in attribute_commitments.iter() {
-            transcript.append_element(b"Com(V)_", &V);
+            transcript.append_element(b"Com(V)_", V);
         }
         // Commit to the padded-to-pow2 number of attributes
         transcript.append_element(

--- a/src/bulletproof.rs
+++ b/src/bulletproof.rs
@@ -493,7 +493,7 @@ impl BulletProof {
     pub fn verify(
         self,
         transcript: &mut CashuTranscript,
-        attribute_commitments: &[(GroupElement, Option<GroupElement>)],
+        attribute_commitments: &[GroupElement],
     ) -> bool {
         transcript.domain_sep(b"Bulletproof_Statement_");
 
@@ -518,7 +518,7 @@ impl BulletProof {
 
         // Append amount commitments to the transcript
         for V in attribute_commitments.iter() {
-            transcript.append_element(b"Com(V)_", &V.0);
+            transcript.append_element(b"Com(V)_", &V);
         }
         // Commit to the padded-to-pow2 number of attributes
         transcript.append_element(
@@ -579,7 +579,7 @@ impl BulletProof {
         // Check that t_x = t(x) = t_0 + t_1*x + t_2*x^2     (72)
         let mut V_z_m = GENERATORS.O.clone();
         for (commitment_pair, z_j) in izip!(attribute_commitments.iter(), z_list.iter()) {
-            V_z_m = V_z_m + &(commitment_pair.0.clone() * z_j);
+            V_z_m = V_z_m + &(commitment_pair.clone() * z_j);
         }
         if GENERATORS.G_amount.clone() * &t_x + &(GENERATORS.G_blind.clone() * &tau_x)
             != V_z_m * &z_list[2]
@@ -670,7 +670,7 @@ mod tests {
         ];
         let mut attribute_commitments = Vec::new();
         for attr in attributes.iter() {
-            attribute_commitments.push((attr.commitment().clone(), None));
+            attribute_commitments.push(attr.commitment().clone());
         }
         let range_proof = BulletProof::new(&mut cli_tscr, &attributes);
         assert!(range_proof.verify(&mut mint_tscr, &attribute_commitments))
@@ -684,7 +684,7 @@ mod tests {
             vec![AmountAttribute::new(0, None), AmountAttribute::new(0, None)];
         let mut attribute_commitments = Vec::new();
         for attr in attributes.iter() {
-            attribute_commitments.push((attr.commitment().clone(), None));
+            attribute_commitments.push(attr.commitment().clone());
         }
         let range_proof = BulletProof::new(&mut cli_tscr, &attributes);
         //println!("{:?}", serde_json::to_string_pretty(&range_proof).unwrap());
@@ -701,7 +701,7 @@ mod tests {
         ];
         let mut attribute_commitments = Vec::new();
         for attr in attributes.iter() {
-            attribute_commitments.push((attr.commitment().clone(), None));
+            attribute_commitments.push(attr.commitment().clone());
         }
         let range_proof = BulletProof::new(&mut cli_tscr, &attributes);
         assert!(!range_proof.verify(&mut mint_tscr, &attribute_commitments))

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -1,3 +1,5 @@
+//! Defines the generators and contains implementation for "HashToG" functions
+
 use crate::errors::Error;
 use crate::secp::{GroupElement, GROUP_ELEMENT_ZERO};
 use bitcoin::hashes::sha256::Hash as Sha256Hash;

--- a/src/kvac.rs
+++ b/src/kvac.rs
@@ -516,11 +516,6 @@ impl BalanceProof {
     ///
     /// # Returns
     /// A `ZKP` representing the zero-knowledge proof of the balance.
-    ///
-    /// # Example
-    /// ```
-    /// let proof = BalanceProof::create(&inputs, &outputs, &mut transcript);
-    /// ```
     pub fn create(
         inputs: &[AmountAttribute],
         outputs: &[AmountAttribute],
@@ -554,11 +549,6 @@ impl BalanceProof {
     ///
     /// # Returns
     /// A boolean indicating whether the proof is valid (`true`) or invalid (`false`).
-    ///
-    /// # Example
-    /// ```
-    /// let is_valid = BalanceProof::verify(&inputs, &outputs, delta_amount, proof, &mut transcript);
-    /// ```
     pub fn verify(
         inputs: &[RandomizedCoin],
         outputs: &[GroupElement],
@@ -596,11 +586,6 @@ impl ScriptEqualityProof {
     ///
     /// # Returns
     /// A `Statement` containing the domain separator and the equations that represent the script equality proof.
-    ///
-    /// # Example
-    /// ```
-    /// let statement = ScriptEqualityProof::statement(&randomized_inputs, &outputs);
-    /// ```
     pub fn statement(
         inputs: &[RandomizedCoin],
         outputs: &[(GroupElement, GroupElement)],
@@ -657,11 +642,6 @@ impl ScriptEqualityProof {
     ///
     /// # Returns
     /// A `Result` containing a `ZKP` representing the zero-knowledge proof of script equality, or an `Error` if the input lists are empty.
-    ///
-    /// # Example
-    /// ```
-    /// let proof = ScriptEqualityProof::create(&inputs, &randomized_inputs, &outputs, &mut transcript)?;
-    /// ```
     pub fn create(
         inputs: &[Coin],
         randomized_inputs: &[RandomizedCoin],
@@ -721,11 +701,6 @@ impl ScriptEqualityProof {
     ///
     /// # Returns
     /// A boolean indicating whether the proof is valid (`true`) or invalid (`false`).
-    ///
-    /// # Example
-    /// ```
-    /// let is_valid = ScriptEqualityProof::verify(&randomized_inputs, &outputs, proof, &mut transcript);
-    /// ```
     pub fn verify(
         randomized_inputs: &[RandomizedCoin],
         outputs: &[(GroupElement, GroupElement)],
@@ -754,11 +729,6 @@ impl RangeProof {
     ///
     /// # Returns
     /// A `RangeZKP` representing the bulletproof for the specified attributes.
-    ///
-    /// # Example
-    /// ```
-    /// let range_proof = RangeProof::create_bulletproof(&mut transcript, &attributes);
-    /// ```
     pub fn create_bulletproof(
         transcript: &mut CashuTranscript,
         attributes: &[AmountAttribute],
@@ -776,11 +746,6 @@ impl RangeProof {
     ///
     /// # Returns
     /// A boolean indicating whether the proof is valid (`true`) or invalid (`false`).
-    ///
-    /// # Example
-    /// ```
-    /// let is_valid = RangeProof::verify(&mut transcript, &attribute_commitments, proof);
-    /// ```
     pub fn verify(
         transcript: &mut CashuTranscript,
         attribute_commitments: &[GroupElement],

--- a/src/kvac.rs
+++ b/src/kvac.rs
@@ -459,7 +459,7 @@ impl IParamsProof {
     /// * `transcript` - A mutable reference to a `CashuTranscript` that will be used during the verification.
     ///
     /// # Returns
-    /// 
+    ///
     /// Returns a boolean indicating whether the proof is valid (`true`) or invalid (`false`).
     pub fn verify(
         mint_publickey: &MintPublicKey,

--- a/src/kvac.rs
+++ b/src/kvac.rs
@@ -798,8 +798,8 @@ mod tests {
     #[test]
     fn test_wrong_bootstrap() {
         let (mut mint_transcript, mut client_transcript) = transcripts();
-        let mut bootstrap_attr = AmountAttribute::new(1, None);
-        let proof = BootstrapProof::create(&mut bootstrap_attr, client_transcript.as_mut());
+        let bootstrap_attr = AmountAttribute::new(1, None);
+        let proof = BootstrapProof::create(&bootstrap_attr, client_transcript.as_mut());
         assert!(!BootstrapProof::verify(
             &bootstrap_attr.commitment(),
             proof,

--- a/src/models.rs
+++ b/src/models.rs
@@ -118,7 +118,6 @@ pub struct ScriptAttribute {
 
 #[allow(non_snake_case)]
 impl ScriptAttribute {
-
     /// Creates a new script attribute from a given script and optional blinding factor.
     pub fn new(script: &[u8], blinding_factor: Option<&[u8; 32]>) -> Self {
         let s = Scalar::new(&Sha256Hash::hash(script).to_byte_array());

--- a/src/models.rs
+++ b/src/models.rs
@@ -310,7 +310,7 @@ impl Coin {
     ///
     /// # Returns
     ///
-    /// Returns a new instance of `Coin` containing the provided 
+    /// Returns a new instance of `Coin` containing the provided
     pub fn new(
         amount_attribute: AmountAttribute,
         script_attribute: Option<ScriptAttribute>,
@@ -342,7 +342,7 @@ pub struct RandomizedCoin {
 
 impl RandomizedCoin {
     /// Create a randomized coin, with randomized commitments from a normal `Coin`.
-    /// 
+    ///
     /// `reveal_script` must be set to true if the script inside the `ScriptAttribute`
     /// will be revealed to the Mint/server.
     ///

--- a/src/models.rs
+++ b/src/models.rs
@@ -124,8 +124,8 @@ impl ScriptAttribute {
     ///
     /// * `script` - A slice of bytes representing the script. This is used to generate the scalar `s`.
     /// * `blinding_factor` - An optional reference to a 32-byte array that serves as the blinding factor.
-    ///                       If provided, it is used to create the scalar `r`. If not provided, a random
-    ///                       scalar `r` is generated.
+    ///   If provided, it is used to create the scalar `r`. If not provided, a random
+    ///   scalar `r` is generated.
     ///
     /// # Returns
     ///
@@ -189,8 +189,8 @@ impl AmountAttribute {
     ///
     /// * `amount` - A `u64` representing the amount to be associated with the attribute. This is used to create the scalar `a`.
     /// * `blinding_factor` - An optional reference to a 32-byte array that serves as the blinding factor.
-    ///                       If provided, it is used to create the scalar `r`. If not provided, a random
-    ///                       scalar `r` is generated.
+    ///   If provided, it is used to create the scalar `r`. If not provided, a random
+    ///   scalar `r` is generated.
     ///
     /// # Returns
     ///
@@ -249,9 +249,9 @@ impl MAC {
     /// * `privkey` - A reference to the `MintPrivateKey` used to generate the MAC.
     /// * `amount_commitment` - A reference to a `GroupElement` representing the amount commitment.
     /// * `script_commitment` - An optional reference to a `GroupElement` representing the script commitment.
-    ///                         If not provided, a zero `GroupElement` is used.
+    ///   If not provided, a zero `GroupElement` is used.
     /// * `t_tag` - An optional reference to a `Scalar` that can be used as a tag. If not provided, a random
-    ///              `Scalar` is generated.
+    ///   `Scalar` is generated.
     ///
     /// # Returns
     ///
@@ -350,9 +350,9 @@ impl RandomizedCoin {
     ///
     /// * `coin` - A reference to a `Coin` instance from which the randomized coin will be created.
     /// * `reveal_script` - A boolean indicating whether the script inside the `ScriptAttribute`
-    ///                     will be revealed. If true, the randomized script commitment will be void,
-    ///                     leaving space for the Mint to "fill in" the blank with the hash of the
-    ///                     script (spending conditions) provided by the user
+    ///   will be revealed. If true, the randomized script commitment will be void,
+    ///   leaving space for the Mint to "fill in" the blank with the hash of the
+    ///   script (spending conditions) provided by the user
     ///
     /// # Returns
     ///

--- a/src/secp.rs
+++ b/src/secp.rs
@@ -29,12 +29,12 @@ pub enum TweakKind {
     AMOUNT,
 }
 
-#[derive(Clone, Debug, Eq, Default)]
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub struct Scalar {
     inner: Option<SecretKey>,
 }
 
-#[derive(Hash, Clone, Debug, Eq, Default)]
+#[derive(Hash, Clone, Debug, Eq, PartialEq, Default)]
 pub struct GroupElement {
     inner: Option<PublicKey>,
 }
@@ -378,29 +378,6 @@ impl AsRef<Scalar> for Scalar {
     }
 }
 
-impl PartialEq for Scalar {
-    fn eq(&self, other: &Self) -> bool {
-        if self.inner.is_none() && other.inner.is_none() {
-            return true;
-        }
-        if self.inner.is_none() || other.inner.is_none() {
-            return false;
-        }
-        let mut b = 0u8;
-        for (x, y) in self
-            .inner
-            .as_ref()
-            .unwrap()
-            .secret_bytes()
-            .iter()
-            .zip(other.inner.as_ref().unwrap().secret_bytes().iter())
-        {
-            b |= x ^ y;
-        }
-        b == 0
-    }
-}
-
 impl Serialize for Scalar {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -480,19 +457,6 @@ impl std::ops::Mul<&Scalar> for GroupElement {
             self.multiply(&(r + other));
             self_copy.multiply(&r_copy);
             self - &self_copy
-        }
-    }
-}
-
-impl PartialEq for GroupElement {
-    fn eq(&self, other: &Self) -> bool {
-        if self.inner.is_none() && other.inner.is_none() {
-            return true;
-        }
-        if self.inner.is_none() || other.inner.is_none() {
-            false
-        } else {
-            self.inner.unwrap().eq(&other.inner.unwrap())
         }
     }
 }

--- a/src/secp.rs
+++ b/src/secp.rs
@@ -30,11 +30,13 @@ pub enum TweakKind {
 }
 
 #[derive(Clone, Debug, Eq)]
+#[derive(Default)]
 pub struct Scalar {
     inner: Option<SecretKey>,
 }
 
 #[derive(Hash, Clone, Debug, Eq)]
+#[derive(Default)]
 pub struct GroupElement {
     inner: Option<PublicKey>,
 }
@@ -423,11 +425,6 @@ impl<'de> Deserialize<'de> for Scalar {
     }
 }
 
-impl Default for Scalar {
-    fn default() -> Self {
-        Scalar { inner: None }
-    }
-}
 
 impl Hash for Scalar {
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -572,11 +569,6 @@ impl<'de> Deserialize<'de> for GroupElement {
     }
 }
 
-impl Default for GroupElement {
-    fn default() -> Self {
-        GroupElement { inner: None }
-    }
-}
 
 #[cfg(test)]
 mod tests {
@@ -849,7 +841,7 @@ mod tests {
         let mut ge = GENERATORS.G_amount.clone();
         ge = ge * &Scalar::from(2);
 
-        let tweak = 4 as u64;
+        let tweak = 4_u64;
 
         ge.tweak(TweakKind::AMOUNT, tweak);
         assert_eq!(ge, GENERATORS.G_amount.clone() * &Scalar::from(6));

--- a/src/secp.rs
+++ b/src/secp.rs
@@ -423,7 +423,6 @@ impl<'de> Deserialize<'de> for Scalar {
     }
 }
 
-
 impl Hash for Scalar {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.inner.is_none().hash(state);
@@ -566,7 +565,6 @@ impl<'de> Deserialize<'de> for GroupElement {
         Ok(ge)
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/secp.rs
+++ b/src/secp.rs
@@ -29,14 +29,12 @@ pub enum TweakKind {
     AMOUNT,
 }
 
-#[derive(Clone, Debug, Eq)]
-#[derive(Default)]
+#[derive(Clone, Debug, Eq, Default)]
 pub struct Scalar {
     inner: Option<SecretKey>,
 }
 
-#[derive(Hash, Clone, Debug, Eq)]
-#[derive(Default)]
+#[derive(Hash, Clone, Debug, Eq, Default)]
 pub struct GroupElement {
     inner: Option<PublicKey>,
 }

--- a/src/secp.rs
+++ b/src/secp.rs
@@ -116,7 +116,7 @@ impl Scalar {
         let inner = SecretKey::new(&mut rand::thread_rng());
         Scalar { inner: Some(inner) }
     }
-    
+
     /// Multiplies the current `Scalar` by another `Scalar` using a tweak.
     ///
     /// If either `self` or `other` is zero (i.e., `inner` is `None`), the result will
@@ -368,7 +368,7 @@ impl GroupElement {
     /// Applies a tweak to the current `GroupElement`.
     ///
     /// This method modifies `self` based on the specified `tweak_kind` and `tweak` value.
-    /// Currently, it only supports the `TweakKind::AMOUNT` variant, which combines `self` 
+    /// Currently, it only supports the `TweakKind::AMOUNT` variant, which combines `self`
     /// with a generator multiplied by the given tweak.
     ///
     /// # Arguments

--- a/src/secp.rs
+++ b/src/secp.rs
@@ -25,15 +25,18 @@ pub static SECP256K1: Lazy<Secp256k1<All>> = Lazy::new(|| {
     ctx
 });
 
+/// Defines different kinds of tweaks to be applied to `GroupElement` or `Scalar`
 pub enum TweakKind {
     AMOUNT,
 }
 
+/// Wraps a `secp256k1::key::SecretKey` or `None`
 #[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub struct Scalar {
     inner: Option<SecretKey>,
 }
 
+/// Wraps a `secp256k1::key::PublicKey` or `None`
 #[derive(Hash, Clone, Debug, Eq, PartialEq, Default)]
 pub struct GroupElement {
     inner: Option<PublicKey>,
@@ -79,6 +82,19 @@ fn modinv(m: &Integer, x: &Integer) -> Integer {
 }
 
 impl Scalar {
+    /// Creates a new `Scalar` instance from the provided byte slice.
+    ///
+    /// If the provided data is equal to `SCALAR_ZERO`, the `Scalar` will be initialized
+    /// with `inner` set to `None`. Otherwise, it attempts to create a `SecretKey` from
+    /// the byte slice and wraps it in `Some`.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - A byte slice representing the scalar value.
+    ///
+    /// # Returns
+    ///
+    /// A new `Scalar` instance.
     pub fn new(data: &[u8]) -> Self {
         if *data == SCALAR_ZERO {
             Scalar { inner: None }
@@ -88,11 +104,31 @@ impl Scalar {
         }
     }
 
+    /// Generates a new random `Scalar` instance.
+    ///
+    /// This method uses `rand::thread_rng` to create a new `SecretKey` and wraps
+    /// it in `Some`.
+    ///
+    /// # Returns
+    ///
+    /// A new `Scalar` instance with a random value.
     pub fn random() -> Self {
         let inner = SecretKey::new(&mut rand::thread_rng());
         Scalar { inner: Some(inner) }
     }
-
+    
+    /// Multiplies the current `Scalar` by another `Scalar` using a tweak.
+    ///
+    /// If either `self` or `other` is zero (i.e., `inner` is `None`), the result will
+    /// be set to zero. Otherwise, it performs the multiplication and updates `self`.
+    ///
+    /// # Arguments
+    ///
+    /// * `other` - A reference to another `Scalar` to multiply with.
+    ///
+    /// # Returns
+    ///
+    /// A mutable reference to `self`.
     pub fn tweak_mul(&mut self, other: &Scalar) -> &Self {
         if other.inner.is_none() || self.inner.is_none() {
             self.inner = None;
@@ -108,6 +144,18 @@ impl Scalar {
         self
     }
 
+    /// Adds another `Scalar` to the current `Scalar` using a tweak.
+    ///
+    /// If `other` is zero, it returns `self`. If `self` is zero, it sets `self` to
+    /// `other`. Otherwise, it performs the addition and updates `self`.
+    ///
+    /// # Arguments
+    ///
+    /// * `other` - A reference to another `Scalar` to add.
+    ///
+    /// # Returns
+    ///
+    /// A mutable reference to `self`.
     pub fn tweak_add(&mut self, other: &Scalar) -> &Self {
         if other.inner.is_none() {
             self
@@ -126,6 +174,14 @@ impl Scalar {
         }
     }
 
+    /// Negates the current `Scalar`.
+    ///
+    /// If `self` is zero, it returns `self` unchanged. Otherwise, it negates the value
+    /// and updates `self`.
+    ///
+    /// # Returns
+    ///
+    /// A mutable reference to `self`.
     pub fn tweak_neg(&mut self) -> &Self {
         if self.inner.is_none() {
             self
@@ -136,6 +192,14 @@ impl Scalar {
         }
     }
 
+    /// Computes the multiplicative inverse of the current `Scalar`.
+    ///
+    /// If `self` is zero, it panics with an error message. Otherwise, it calculates
+    /// the inverse and returns a new `Scalar` instance containing the result.
+    ///
+    /// # Returns
+    ///
+    /// A new `Scalar` instance representing the inverse of `self`.
     pub fn invert(self) -> Self {
         if self.inner.is_none() {
             panic!("Scalar 0 doesn't have an inverse")
@@ -157,6 +221,14 @@ impl Scalar {
         }
     }
 
+    /// Converts the current `Scalar` to a byte vector.
+    ///
+    /// If `self` is zero, it returns a vector containing `SCALAR_ZERO`. Otherwise, it
+    /// returns the byte representation of the `SecretKey` wrapped in `self`.
+    ///
+    /// # Returns
+    ///
+    /// A vector of bytes representing the scalar value.
     pub fn to_bytes(&self) -> Vec<u8> {
         if self.inner.is_none() {
             Vec::from(SCALAR_ZERO)
@@ -165,12 +237,33 @@ impl Scalar {
         }
     }
 
+    /// Checks if the current `Scalar` is zero.
+    ///
+    /// This method returns `true` if `self` is zero (i.e., `inner` is `None`), and
+    /// `false` otherwise.
+    ///
+    /// # Returns
+    ///
+    /// A boolean indicating whether the scalar is zero.
     pub fn is_zero(&self) -> bool {
         self.inner.is_none()
     }
 }
 
 impl GroupElement {
+    /// Creates a new `GroupElement` instance from the provided byte slice.
+    ///
+    /// If the provided data is equal to `GROUP_ELEMENT_ZERO`, the `GroupElement` will be
+    /// initialized with `inner` set to `None`. Otherwise, it attempts to create a `PublicKey`
+    /// from the byte slice and wraps it in `Some`.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - A byte slice representing the group element value.
+    ///
+    /// # Returns
+    ///
+    /// A new `GroupElement` instance.
     pub fn new(data: &[u8]) -> Self {
         if *data == GROUP_ELEMENT_ZERO {
             GroupElement { inner: None }
@@ -180,6 +273,18 @@ impl GroupElement {
         }
     }
 
+    /// Combines the current `GroupElement` with another `GroupElement` using addition.
+    ///
+    /// If `other` is zero (i.e., `inner` is `None`), it returns `self`. If `self` is zero,
+    /// it sets `self` to `other`. Otherwise, it performs the combination and updates `self`.
+    ///
+    /// # Arguments
+    ///
+    /// * `other` - A reference to another `GroupElement` to combine with.
+    ///
+    /// # Returns
+    ///
+    /// A mutable reference to `self`.
     pub fn combine_add(&mut self, other: &GroupElement) -> &Self {
         if other.inner.is_none() {
             self
@@ -197,6 +302,18 @@ impl GroupElement {
         }
     }
 
+    /// Multiplies the current `GroupElement` by a scalar.
+    ///
+    /// If either `scalar` or `self` is zero (i.e., `inner` is `None`), the result will be
+    /// set to zero. Otherwise, it performs the multiplication and updates `self`.
+    ///
+    /// # Arguments
+    ///
+    /// * `scalar` - A reference to a `Scalar` to multiply with.
+    ///
+    /// # Returns
+    ///
+    /// A mutable reference to `self`.
     pub fn multiply(&mut self, scalar: &Scalar) -> &Self {
         if scalar.inner.is_none() || self.inner.is_none() {
             self.inner = None;
@@ -214,6 +331,14 @@ impl GroupElement {
         }
     }
 
+    /// Negates the current `GroupElement`.
+    ///
+    /// If `self` is zero, it returns `self` unchanged. Otherwise, it negates the value
+    /// and updates `self`.
+    ///
+    /// # Returns
+    ///
+    /// A mutable reference to `self`.
     pub fn negate(&mut self) -> &Self {
         if self.inner.is_none() {
             self
@@ -224,6 +349,14 @@ impl GroupElement {
         }
     }
 
+    /// Converts the current `GroupElement` to a byte vector.
+    ///
+    /// If `self` is zero, it returns a vector containing `GROUP_ELEMENT_ZERO`. Otherwise,
+    /// it returns the byte representation of the `PublicKey` wrapped in `self`.
+    ///
+    /// # Returns
+    ///
+    /// A vector of bytes representing the group element value.
     pub fn to_bytes(&self) -> Vec<u8> {
         if self.inner.is_none() {
             Vec::from(GROUP_ELEMENT_ZERO)
@@ -232,6 +365,20 @@ impl GroupElement {
         }
     }
 
+    /// Applies a tweak to the current `GroupElement`.
+    ///
+    /// This method modifies `self` based on the specified `tweak_kind` and `tweak` value.
+    /// Currently, it only supports the `TweakKind::AMOUNT` variant, which combines `self` 
+    /// with a generator multiplied by the given tweak.
+    ///
+    /// # Arguments
+    ///
+    /// * `tweak_kind` - The kind of tweak to apply.
+    /// * `tweak` - A `u64` value representing the tweak.
+    ///
+    /// # Returns
+    ///
+    /// A mutable reference to `self`.
     pub fn tweak(&mut self, tweak_kind: TweakKind, tweak: u64) -> &Self {
         match tweak_kind {
             TweakKind::AMOUNT => {
@@ -243,6 +390,14 @@ impl GroupElement {
         }
     }
 
+    /// Checks if the current `GroupElement` is zero.
+    ///
+    /// This method returns `true` if `self` is zero (i.e., `inner` is `None`), and
+    /// `false` otherwise.
+    ///
+    /// # Returns
+    ///
+    /// A boolean indicating whether the group element is zero.
     pub fn is_zero(&self) -> bool {
         self.inner.is_none()
     }

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -2,6 +2,7 @@ use merlin::Transcript;
 
 use crate::secp::{GroupElement, Scalar};
 
+/// A wrapper around `merlin::Transcript` for Fiat-Shamir transformations.
 pub struct CashuTranscript {
     inner: Transcript,
 }
@@ -13,20 +14,45 @@ impl Default for CashuTranscript {
 }
 
 impl CashuTranscript {
+    /// Creates a new transcript with a Cashu-specific domain separator.
+    /// 
+    /// # Returns
+    /// 
+    /// A new `CashuTranscript` instance.
     pub fn new() -> Self {
         let inner = Transcript::new(b"Secp256k1_Cashu_");
         CashuTranscript { inner }
     }
 
+    /// Appends a domain separation message to the transcript.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `message` - A byte slice representing the domain separation message.
     pub fn domain_sep(&mut self, message: &[u8]) {
         self.inner.append_message(b"dom-sep", message);
     }
 
+    /// Appends a `GroupElement` to the transcript.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `label` - A static byte slice used as a label for the element.
+    /// * `element` - The `GroupElement` to be appended.
     pub fn append_element(&mut self, label: &'static [u8], element: &GroupElement) {
         let element_bytes_compressed: [u8; 33] = element.into();
         self.inner.append_message(label, &element_bytes_compressed);
     }
 
+    /// Computes a challenge scalar from the transcript.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `label` - A static byte slice used as a label for the challenge.
+    /// 
+    /// # Returns
+    /// 
+    /// A `Scalar` derived from the transcript state.
     pub fn get_challenge(&mut self, label: &'static [u8]) -> Scalar {
         let mut challenge: [u8; 32] = [0; 32];
         self.inner.challenge_bytes(label, &mut challenge);
@@ -35,6 +61,7 @@ impl CashuTranscript {
 }
 
 impl AsMut<CashuTranscript> for CashuTranscript {
+    /// Returns a mutable reference to `self`, allowing mutation of the transcript.
     fn as_mut(&mut self) -> &mut Self {
         self
     }

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -15,9 +15,9 @@ impl Default for CashuTranscript {
 
 impl CashuTranscript {
     /// Creates a new transcript with a Cashu-specific domain separator.
-    /// 
+    ///
     /// # Returns
-    /// 
+    ///
     /// A new `CashuTranscript` instance.
     pub fn new() -> Self {
         let inner = Transcript::new(b"Secp256k1_Cashu_");
@@ -25,18 +25,18 @@ impl CashuTranscript {
     }
 
     /// Appends a domain separation message to the transcript.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `message` - A byte slice representing the domain separation message.
     pub fn domain_sep(&mut self, message: &[u8]) {
         self.inner.append_message(b"dom-sep", message);
     }
 
     /// Appends a `GroupElement` to the transcript.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `label` - A static byte slice used as a label for the element.
     /// * `element` - The `GroupElement` to be appended.
     pub fn append_element(&mut self, label: &'static [u8], element: &GroupElement) {
@@ -45,13 +45,13 @@ impl CashuTranscript {
     }
 
     /// Computes a challenge scalar from the transcript.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `label` - A static byte slice used as a label for the challenge.
-    /// 
+    ///
     /// # Returns
-    /// 
+    ///
     /// A `Scalar` derived from the transcript state.
     pub fn get_challenge(&mut self, label: &'static [u8]) -> Scalar {
         let mut challenge: [u8; 32] = [0; 32];


### PR DESCRIPTION
[EDIT]

### Further change/simplification
`create_bulletproof`, `verify` (range proof) and the related statements now accept only `AmountAttribute`s and `GroupElement` commitments for amount attributes.

This changes nothing as `ScriptAttribute`s and their commitments are unused in the range proof.