### PR TITLE
Fix Sum-To-Zero Recovery Edge Case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cashu_kvac"
-version = "0.0.1-alpha"
+version = "0.0.2-alpha"
 dependencies = [
  "bitcoin",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cashu_kvac"
-version = "0.0.1-alpha"
+version = "0.0.2-alpha"
 edition = "2021"
 rust-version = "1.80.1"
 

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -99,7 +99,7 @@ mod tests {
 
         // Suppose we have the amount commitments (recovered from the Mint)
         let amount_attributes = vec![
-            AmountAttribute::new(1997, Some(&blinding_factors[0].to_bytes())),
+            AmountAttribute::new(19, Some(&blinding_factors[0].to_bytes())),
             AmountAttribute::new(763, Some(&blinding_factors[1].to_bytes())),
             AmountAttribute::new(22001, Some(&blinding_factors[2].to_bytes())),
         ];
@@ -120,7 +120,7 @@ mod tests {
             .map(|recovered_amount| recovered_amount.expect("amount is within 100000"))
             .collect();
 
-        assert!(recovered_amounts[0] == 1997);
+        assert!(recovered_amounts[0] == 19);
         assert!(recovered_amounts[1] == 763);
         assert!(recovered_amounts[2] == 22001);
     }

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -49,7 +49,7 @@ pub fn recover_amounts(
 
     // Build table
     let mut table = HashMap::new();
-    let mut index = GENERATORS.O.clone();
+    let mut index = GENERATORS.G_blind.clone();
     table.insert(index.clone(), 0);
 
     let one = GENERATORS.G_amount.clone();
@@ -63,8 +63,8 @@ pub fn recover_amounts(
     // Process commitments
     for (Ma, r_a) in commitments.iter().zip(blinding_factors.iter()) {
         // Unblind the amount commitment
-        let mut A = -GENERATORS.G_blind.clone() * r_a + Ma;
-
+        let mut A = GENERATORS.G_blind.clone() * &(Scalar::from(1) - &r_a) + Ma;
+        
         let mut a = None;
         // Look for a match on the table
         for i in 0..m {

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -63,7 +63,7 @@ pub fn recover_amounts(
     // Process commitments
     for (Ma, r_a) in commitments.iter().zip(blinding_factors.iter()) {
         // Unblind the amount commitment
-        let mut A = GENERATORS.G_blind.clone() * &(Scalar::from(1) - &r_a) + Ma;
+        let mut A = GENERATORS.G_blind.clone() * &(Scalar::from(1) - r_a) + Ma;
 
         let mut a = None;
         // Look for a match on the table

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -64,7 +64,7 @@ pub fn recover_amounts(
     for (Ma, r_a) in commitments.iter().zip(blinding_factors.iter()) {
         // Unblind the amount commitment
         let mut A = GENERATORS.G_blind.clone() * &(Scalar::from(1) - &r_a) + Ma;
-        
+
         let mut a = None;
         // Look for a match on the table
         for i in 0..m {


### PR DESCRIPTION
From `recover_amounts`:
```rust
match table.get(&A) {
    Some(j) => {
        a = Some(i * m + j);
        break;
    }
    None => A = A + &G_m_inv,
}
```

there are cases in which summing `G_m_inv` to `A` makes `A == O` (point to infinity), which isn't supported by libsecp for security reasons.

Solution: unblind with `r-1` instead of `r`. This way `A = a*G_amount + 1*G_blind` and if summing `G_m_inv` nullifies the term in `G_amount`, there still is `G_blind` to prevent it from going to zero.