### PR TITLE
Check ZKP Responses Are Not Zero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.angry-duck
 __pycache__
 python/src/__pycache__
 python/src/merlin/extension

--- a/src/bulletproof.rs
+++ b/src/bulletproof.rs
@@ -236,8 +236,8 @@ impl InnerProductArgument {
         }
 
         // Recursion unrolling - We reduce O(n*log_2(n)) GroupElement multiplications
-        // to O(n) by unrolling the prover's loop (we have the challenges) and
-        // performing the O(log_2(n)) arithmetic operations on scalars instead.
+        // to O(n) by unrolling the prover's loop (we can do that since have the challenges)
+        // and performing the O(log_2(n)) arithmetic operations on scalars instead.
         let mut G_aH_b = GENERATORS.O.clone();
         for (i, (G_i, H_i)) in G_.into_iter().zip(H_.into_iter()).enumerate() {
             let mut s = Scalar::new(&SCALAR_ONE);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -18,6 +18,10 @@ pub enum Error {
     HexStringTooLong,
     #[error("Cannot deserialize from this object")]
     InvalidSerialization,
+    #[error("Cannot instantiate Scalar from hex string zero")]
+    ScalarZero,
+    #[error("Cannot instantiate GroupElement from hex string zero")]
+    GroupElementZero,
     /// Secp256k1 error
     #[error(transparent)]
     Secp256k1(#[from] secp256k1::Error),

--- a/src/kvac.rs
+++ b/src/kvac.rs
@@ -10,6 +10,17 @@ use crate::transcript::CashuTranscript;
 use bitcoin::hashes::sha256::Hash as Sha256Hash;
 use bitcoin::hashes::Hash;
 
+/// Checks if all the elements in the provided slice of `Scalar` values are non-zero.
+///
+/// # Arguments
+/// * `scalars` - A slice of `Scalar` values to be checked.
+///
+/// # Returns
+/// * `true` if all the `Scalar` values in the slice are non-zero, `false` otherwise.
+fn check_scalars_non_zero(scalars: &[Scalar]) -> bool {
+    scalars.iter().all(|scalar| !scalar.is_zero())
+}
+
 pub struct SchnorrProver<'a> {
     random_terms: Vec<Scalar>,
     secrets: Vec<Scalar>,
@@ -149,6 +160,9 @@ impl<'a> SchnorrVerifier<'a> {
     ///
     /// Returns a boolean indicating whether the proof is valid (`true`) or invalid (`false`).
     pub fn verify(&mut self) -> bool {
+        if !check_scalars_non_zero(&self.responses) {
+            return false;
+        }
         let challenge_ = self.transcript.get_challenge(b"chall_");
         challenge_ == self.challenge
     }

--- a/src/secp.rs
+++ b/src/secp.rs
@@ -524,7 +524,7 @@ impl TryFrom<&str> for Scalar {
         let mut padded_bytes = [0u8; 32];
         padded_bytes[32 - bytes.len()..32].copy_from_slice(&bytes);
         if padded_bytes == SCALAR_ZERO {
-            return Err(Error::ScalarZero)
+            return Err(Error::ScalarZero);
         }
         Ok(Scalar::new(&padded_bytes))
     }
@@ -629,7 +629,7 @@ impl TryFrom<&str> for GroupElement {
         let mut padded_bytes = [0u8; 33];
         padded_bytes[33 - bytes.len()..33].copy_from_slice(&bytes);
         if padded_bytes == GROUP_ELEMENT_ZERO {
-            return Err(Error::GroupElementZero)
+            return Err(Error::GroupElementZero);
         }
         Ok(GroupElement::new(&padded_bytes))
     }

--- a/src/secp.rs
+++ b/src/secp.rs
@@ -523,6 +523,9 @@ impl TryFrom<&str> for Scalar {
         }
         let mut padded_bytes = [0u8; 32];
         padded_bytes[32 - bytes.len()..32].copy_from_slice(&bytes);
+        if padded_bytes == SCALAR_ZERO {
+            return Err(Error::ScalarZero)
+        }
         Ok(Scalar::new(&padded_bytes))
     }
 }
@@ -625,6 +628,9 @@ impl TryFrom<&str> for GroupElement {
         }
         let mut padded_bytes = [0u8; 33];
         padded_bytes[33 - bytes.len()..33].copy_from_slice(&bytes);
+        if padded_bytes == GROUP_ELEMENT_ZERO {
+            return Err(Error::GroupElementZero)
+        }
         Ok(GroupElement::new(&padded_bytes))
     }
 }


### PR DESCRIPTION
In cashu-kvac we're bypassing libsecp256 non-zero policy restrictions (errors on any zero value) by simply setting `GroupElement::inner = None` and `Scalar::inner = None` instead of instantiating them ([here](https://github.com/lollerfirst/cashu-kvac/blob/2d55a3b3a9016cc84ee6963fe1ffca703689fa2a/src/secp.rs#L34) and [here](https://github.com/lollerfirst/cashu-kvac/blob/2d55a3b3a9016cc84ee6963fe1ffca703689fa2a/src/secp.rs#L41)).

This creates a potential security issue: by committing `O` (point at infinity, sent for example as [02][00]*32) and then sending zero ([00] * 32) responses to the challenge, an attacker creates a technically acceptable proof.

```math
\displaylines{
O \text{ is the point at infinity }\\
Com(O)\\
c \leftarrow \text{challenge}\\
\vec{z} = [0, 0, ..., 0]  \  \ \text{(responses)}\\
\text{verify: } O \stackrel{?}= z_0 \cdot G + z_1 \cdot H + \ldots + z_n \cdot X = 0 \cdot G + 0 \cdot H + \ldots + 0 \cdot X\\
}
```

If this is a MAC proof, this means that `O` is a valid MAC for whatever private key of the Mint (recall the MAC proof construction [here](https://github.com/lollerfirst/cashu-kvac/blob/2d55a3b3a9016cc84ee6963fe1ffca703689fa2a/protocol_explanation.md?plain=1#L271)):
```math
\displaylines{
Z \stackrel{?}= 0 \cdot I\\
C_a \stackrel{?} = 0 \cdot G_\text{zamount} + 0 \cdot G_\text{blind} + 0 \cdot G_\text{amount}\\
C_{x_1} \stackrel{?}= 0\cdot C_{x_0} - 0\cdot G_{x_0} + 0\cdot G_{x_1}\\
\text{with } \ Z = O - (w\cdot O + x_0\cdot O + x_1\cdot O + y_a\cdot O + y_s\cdot O)\\
}
```
Now this would not have caused inflation, because this MAC would be bound to an amount commitment of value $0$ and unknown script hash (preimage of hash [00]*32). But still, this is something that should be fixed.