### PR TITLE
Add Debug Mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.4-alpha"
 edition = "2021"
 rust-version = "1.80.1"
 
+[features]
+default = []
+proof-debug = []
+
 [lib]
 path = "src/lib.rs"
 crate-type = ["cdylib", "rlib"]

--- a/src/bulletproof.rs
+++ b/src/bulletproof.rs
@@ -333,7 +333,8 @@ impl BulletProof {
         }
         transcript.append_element(
             b"Com(m)_",
-            &hash_to_curve(&(m as u32).to_be_bytes()).expect("Couldn't map m length to GroupElement"),
+            &hash_to_curve(&(m as u32).to_be_bytes())
+                .expect("Couldn't map m length to GroupElement"),
         );
 
         // Get generators
@@ -378,7 +379,7 @@ impl BulletProof {
 
         // Get y challenge
         let y = transcript.get_challenge(b"y_chall_");
-        
+
         // Commit y
         let y_bytes: [u8; 32] = y.as_ref().into();
         transcript.append_element(b"Com(y)_", &hash_to_curve(&y_bytes).unwrap());
@@ -548,7 +549,8 @@ impl BulletProof {
         // Commit to the padded-to-pow2 number of attributes
         transcript.append_element(
             b"Com(m)_",
-            &hash_to_curve(&(m as u32).to_be_bytes()).expect("Couldn't map m length to GroupElement"),
+            &hash_to_curve(&(m as u32).to_be_bytes())
+                .expect("Couldn't map m length to GroupElement"),
         );
 
         // Append A and S to transcript

--- a/src/bulletproof.rs
+++ b/src/bulletproof.rs
@@ -333,7 +333,7 @@ impl BulletProof {
         }
         transcript.append_element(
             b"Com(m)_",
-            &hash_to_curve(&m.to_be_bytes()).expect("Couldn't map m length to GroupElement"),
+            &hash_to_curve(&(m as u32).to_be_bytes()).expect("Couldn't map m length to GroupElement"),
         );
 
         // Get generators
@@ -378,7 +378,7 @@ impl BulletProof {
 
         // Get y challenge
         let y = transcript.get_challenge(b"y_chall_");
-
+        
         // Commit y
         let y_bytes: [u8; 32] = y.as_ref().into();
         transcript.append_element(b"Com(y)_", &hash_to_curve(&y_bytes).unwrap());
@@ -548,7 +548,7 @@ impl BulletProof {
         // Commit to the padded-to-pow2 number of attributes
         transcript.append_element(
             b"Com(m)_",
-            &hash_to_curve(&m.to_be_bytes()).expect("Couldn't map m length to GroupElement"),
+            &hash_to_curve(&(m as u32).to_be_bytes()).expect("Couldn't map m length to GroupElement"),
         );
 
         // Append A and S to transcript

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -91,13 +91,14 @@ mod tests {
 
     #[test]
     fn test_hash_to_curve() {
-        let msg = b"G_amount";
-        let g_amount = GroupElement::try_from(
+        let msg = hex::decode("000000").expect("valid hex");
+        /*let g_amount = GroupElement::try_from(
             "024e76426e405fa7f7d3403ea8671fe11b8bec2da6dcda5583ce1ac37ed0de9b04",
         )
-        .unwrap();
-        let g_amount_ = hash_to_curve(msg).expect("Couldn't map hash to groupelement");
-        assert!(g_amount == g_amount_)
+        .unwrap();*/
+        let ge = hash_to_curve(&msg).expect("Couldn't map hash to groupelement");
+        println!("ge: {}\n", serde_json::to_string(&ge).unwrap());
+        //assert!(g_amount == g_amount_)
     }
 
     #[test]

--- a/src/secp.rs
+++ b/src/secp.rs
@@ -131,11 +131,14 @@ impl Scalar {
     pub fn random() -> Self {
         #[cfg(feature = "proof-debug")]
         {
-            let inner = SecretKey::new(&SCALAR_ONE);
-            return Scalar { inner: Some(inner) };
+            let inner = SecretKey::from_slice(&SCALAR_ONE).expect("1 is a valid scalar");
+            Scalar { inner: Some(inner) }
         }
-        let inner = SecretKey::new(&mut rand::thread_rng());
-        Scalar { inner: Some(inner) }        
+        #[cfg(not(feature = "proof-debug"))]
+        {
+            let inner = SecretKey::new(&mut rand::thread_rng());
+            Scalar { inner: Some(inner) }
+        }
     }
 
     /// Multiplies the current `Scalar` by another `Scalar` using a tweak.

--- a/src/secp.rs
+++ b/src/secp.rs
@@ -129,8 +129,13 @@ impl Scalar {
     ///
     /// A new `Scalar` instance with a random value.
     pub fn random() -> Self {
+        #[cfg(feature = "proof-debug")]
+        {
+            let inner = SecretKey::new(&SCALAR_ONE);
+            return Scalar { inner: Some(inner) };
+        }
         let inner = SecretKey::new(&mut rand::thread_rng());
-        Scalar { inner: Some(inner) }
+        Scalar { inner: Some(inner) }        
     }
 
     /// Multiplies the current `Scalar` by another `Scalar` using a tweak.

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -4,6 +4,7 @@ use serde_wasm_bindgen::{from_value, to_value};
 use wasm_bindgen::JsValue;
 use wasm_bindgen::{prelude::wasm_bindgen, JsError};
 
+use crate::generators::hash_to_curve;
 use crate::{
     bulletproof::BulletProof,
     kvac::{BalanceProof, BootstrapProof, IParamsProof, MacProof, ScriptEqualityProof},
@@ -330,4 +331,11 @@ impl CashuTranscript {
     pub fn wasmCreateNew() -> Self {
         Self::new()
     }
+}
+
+#[wasm_bindgen]
+pub fn wasmHashToG(hex: String) -> Result<JsValue, JsError> {
+    let bytes = hex::decode(hex).map_err(|e| JsError::new(&format!("{}", e)))?;
+    let ge = hash_to_curve(&bytes).expect("can map to GroupElement");
+    Ok(ge.toJSON())
 }


### PR DESCRIPTION
### Debug
Adds a feature debug mode (`proof-debug`) for random `Scalar` values. If enabled, all random scalars are 1.

### Bug Fix
Fixed a bug with `BulletProof` where a value of `usize` was committed to the transcript. `usize` can be of multiple different bit-lengths depending on the platform, so the proof won't be the same cross-platform. Fixed that by casting to `u32`