### PR TITLE
Refactor `IssuanceProof`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cashu_kvac"
-version = "0.0.4-alpha"
+version = "0.0.5-alpha"
 dependencies = [
  "bitcoin",
  "getrandom",

--- a/benches/proofs_bench.rs
+++ b/benches/proofs_bench.rs
@@ -1,11 +1,17 @@
 #![feature(test)]
 extern crate test;
 use cashu_kvac::{
-    bulletproof::BulletProof, generators::GENERATORS, models::{AmountAttribute, Coin, MintPrivateKey, RandomizedCoin, ScriptAttribute, MAC}, secp::{GroupElement, Scalar}, transcript::CashuTranscript
+    bulletproof::BulletProof,
+    generators::GENERATORS,
+    models::{AmountAttribute, Coin, MintPrivateKey, RandomizedCoin, ScriptAttribute, MAC},
+    secp::{GroupElement, Scalar},
+    transcript::CashuTranscript,
 };
 use test::Bencher;
 
-use cashu_kvac::kvac::{BalanceProof, BootstrapProof, IssuanceProof, MacProof, ScriptEqualityProof};
+use cashu_kvac::kvac::{
+    BalanceProof, BootstrapProof, IssuanceProof, MacProof, ScriptEqualityProof,
+};
 
 fn transcripts() -> (CashuTranscript, CashuTranscript) {
     let mint_transcript = CashuTranscript::new();
@@ -31,14 +37,7 @@ fn bench_iparams_proof(bencher: &mut Bencher) {
     let amount_attr = AmountAttribute::new(12, None);
     let mac = MAC::generate(&mint_privkey, &amount_attr.commitment(), None, None)
         .expect("Couldn't generate MAC");
-    bencher.iter(|| {
-        IssuanceProof::create(
-            &mint_privkey,
-            &mac,
-            &amount_attr.commitment(),
-            None,
-        )
-    });
+    bencher.iter(|| IssuanceProof::create(&mint_privkey, &mac, &amount_attr.commitment(), None));
 }
 
 #[bench]
@@ -164,20 +163,9 @@ fn bench_iparams_proof_verification(bencher: &mut Bencher) {
     let amount_attr = AmountAttribute::new(12, None);
     let mac = MAC::generate(&mint_privkey, &amount_attr.commitment(), None, None)
         .expect("Couldn't generate MAC");
-    let proof = IssuanceProof::create(
-        &mint_privkey,
-        &mac,
-        &amount_attr.commitment(),
-        None,
-    );
+    let proof = IssuanceProof::create(&mint_privkey, &mac, &amount_attr.commitment(), None);
     let coin = Coin::new(amount_attr, None, mac);
-    bencher.iter(|| {
-        IssuanceProof::verify(
-            &mint_privkey.public_key,
-            &coin,
-            proof.clone(),
-        )
-    });
+    bencher.iter(|| IssuanceProof::verify(&mint_privkey.public_key, &coin, proof.clone()));
 }
 
 #[bench]

--- a/src/kvac.rs
+++ b/src/kvac.rs
@@ -363,10 +363,10 @@ impl MacProof {
 }
 
 #[wasm_bindgen]
-pub struct IParamsProof;
+pub struct IssuanceProof;
 
 #[allow(non_snake_case)]
-impl IParamsProof {
+impl IssuanceProof {
     /// Creates a statement for the IParams proof, which includes the necessary equations.
     ///
     /// # Arguments
@@ -421,7 +421,6 @@ impl IParamsProof {
     /// * `mac` - A reference to the `MAC` instance associated with the proof.
     /// * `amount_commitment` - A reference to a `GroupElement` representing the amount commitment.
     /// * `script_commitment` - An optional reference to a `GroupElement` representing the script commitment.
-    /// * `transcript` - A mutable reference to a `CashuTranscript` that will be used during the proof creation.
     ///
     /// # Returns
     ///
@@ -431,19 +430,19 @@ impl IParamsProof {
         mac: &MAC,
         amount_commitment: &GroupElement,
         script_commitment: Option<&GroupElement>,
-        transcript: &mut CashuTranscript,
     ) -> ZKP {
+        let mut transcript = CashuTranscript::new();
         let script_commitment: &GroupElement = match script_commitment {
             Some(scr) => scr,
             None => GENERATORS.O.as_ref(),
         };
-        let statement = IParamsProof::statement(
+        let statement = IssuanceProof::statement(
             &mint_privkey.public_key,
             mac,
             amount_commitment,
             script_commitment,
         );
-        SchnorrProver::new(transcript, mint_privkey.to_scalars())
+        SchnorrProver::new(&mut transcript, mint_privkey.to_scalars())
             .add_statement(statement)
             .prove()
     }
@@ -464,19 +463,19 @@ impl IParamsProof {
         mint_publickey: &MintPublicKey,
         coin: &Coin,
         proof: ZKP,
-        transcript: &mut CashuTranscript,
     ) -> bool {
+        let mut transcript = CashuTranscript::new();
         let script_commitment: GroupElement = match &coin.script_attribute {
             Some(scr) => scr.commitment(),
             None => GENERATORS.O,
         };
-        let statement = IParamsProof::statement(
+        let statement = IssuanceProof::statement(
             mint_publickey,
             &coin.mac,
             &coin.amount_attribute.commitment(),
             &script_commitment,
         );
-        SchnorrVerifier::new(transcript, proof)
+        SchnorrVerifier::new(&mut transcript, proof)
             .add_statement(statement)
             .verify()
     }
@@ -755,7 +754,7 @@ mod tests {
         transcript::CashuTranscript,
     };
 
-    use super::{BalanceProof, BootstrapProof, IParamsProof, MacProof, ScriptEqualityProof};
+    use super::{BalanceProof, BootstrapProof, IssuanceProof, MacProof, ScriptEqualityProof};
 
     fn transcripts() -> (CashuTranscript, CashuTranscript) {
         let mint_transcript = CashuTranscript::new();
@@ -794,48 +793,42 @@ mod tests {
 
     #[test]
     fn test_iparams() {
-        let (mut mint_transcript, mut client_transcript) = transcripts();
         let mint_privkey = privkey();
         let amount_attr = AmountAttribute::new(12, None);
         let mac = MAC::generate(&mint_privkey, &amount_attr.commitment(), None, None)
             .expect("Couldn't generate MAC");
-        let proof = IParamsProof::create(
+        let proof = IssuanceProof::create(
             &mint_privkey,
             &mac,
             &amount_attr.commitment(),
             None,
-            &mut client_transcript,
         );
         let coin = Coin::new(amount_attr, None, mac);
-        assert!(IParamsProof::verify(
+        assert!(IssuanceProof::verify(
             &mint_privkey.public_key,
             &coin,
             proof,
-            &mut mint_transcript
         ));
     }
 
     #[test]
     fn test_wrong_iparams() {
-        let (mut mint_transcript, mut client_transcript) = transcripts();
         let mint_privkey = privkey();
         let mint_privkey_1 = privkey();
         let amount_attr = AmountAttribute::new(12, None);
         let mac = MAC::generate(&mint_privkey, &amount_attr.commitment(), None, None)
             .expect("Couldn't generate MAC");
-        let proof = IParamsProof::create(
+        let proof = IssuanceProof::create(
             &mint_privkey,
             &mac,
             &amount_attr.commitment(),
             None,
-            &mut client_transcript,
         );
         let coin = Coin::new(amount_attr, None, mac);
-        assert!(!IParamsProof::verify(
+        assert!(!IssuanceProof::verify(
             &mint_privkey_1.public_key,
             &coin,
             proof,
-            &mut mint_transcript
         ))
     }
 

--- a/src/kvac.rs
+++ b/src/kvac.rs
@@ -459,11 +459,7 @@ impl IssuanceProof {
     /// # Returns
     ///
     /// Returns a boolean indicating whether the proof is valid (`true`) or invalid (`false`).
-    pub fn verify(
-        mint_publickey: &MintPublicKey,
-        coin: &Coin,
-        proof: ZKP,
-    ) -> bool {
+    pub fn verify(mint_publickey: &MintPublicKey, coin: &Coin, proof: ZKP) -> bool {
         let mut transcript = CashuTranscript::new();
         let script_commitment: GroupElement = match &coin.script_attribute {
             Some(scr) => scr.commitment(),
@@ -797,12 +793,7 @@ mod tests {
         let amount_attr = AmountAttribute::new(12, None);
         let mac = MAC::generate(&mint_privkey, &amount_attr.commitment(), None, None)
             .expect("Couldn't generate MAC");
-        let proof = IssuanceProof::create(
-            &mint_privkey,
-            &mac,
-            &amount_attr.commitment(),
-            None,
-        );
+        let proof = IssuanceProof::create(&mint_privkey, &mac, &amount_attr.commitment(), None);
         let coin = Coin::new(amount_attr, None, mac);
         assert!(IssuanceProof::verify(
             &mint_privkey.public_key,
@@ -818,12 +809,7 @@ mod tests {
         let amount_attr = AmountAttribute::new(12, None);
         let mac = MAC::generate(&mint_privkey, &amount_attr.commitment(), None, None)
             .expect("Couldn't generate MAC");
-        let proof = IssuanceProof::create(
-            &mint_privkey,
-            &mac,
-            &amount_attr.commitment(),
-            None,
-        );
+        let proof = IssuanceProof::create(&mint_privkey, &mac, &amount_attr.commitment(), None);
         let coin = Coin::new(amount_attr, None, mac);
         assert!(!IssuanceProof::verify(
             &mint_privkey_1.public_key,

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -7,7 +7,7 @@ use wasm_bindgen::{prelude::wasm_bindgen, JsError};
 use crate::generators::hash_to_curve;
 use crate::{
     bulletproof::BulletProof,
-    kvac::{BalanceProof, BootstrapProof, IParamsProof, MacProof, ScriptEqualityProof},
+    kvac::{BalanceProof, BootstrapProof, IssuanceProof, MacProof, ScriptEqualityProof},
     models::{
         AmountAttribute, Coin, MintPrivateKey, MintPublicKey, RandomizedCoin, ScriptAttribute, MAC,
         ZKP,
@@ -186,25 +186,23 @@ impl MacProof {
 }
 
 #[wasm_bindgen]
-impl IParamsProof {
+impl IssuanceProof {
     pub fn wasmCreate(
         mintPrivkey: JsValue,
         mac: JsValue,
         amountCommitment: JsValue,
         scriptCommitment: JsValue,
-        transcript: &mut CashuTranscript,
     ) -> Result<JsValue, JsError> {
         let mintPrivkey: MintPrivateKey = MintPrivateKey::fromJSON(mintPrivkey)?;
         let mac: MAC = MAC::fromJSON(mac)?;
         let amountCommitment: GroupElement = GroupElement::fromJSON(amountCommitment)?;
         let scriptCommitment: Option<GroupElement> =
             from_value(scriptCommitment).map_err(|e| JsError::new(&format!("{}", e)))?;
-        Ok(IParamsProof::create(
+        Ok(IssuanceProof::create(
             &mintPrivkey,
             &mac,
             &amountCommitment,
             scriptCommitment.as_ref(),
-            transcript,
         )
         .toJSON())
     }
@@ -213,16 +211,14 @@ impl IParamsProof {
         mintPublickey: JsValue,
         coin: JsValue,
         proof: JsValue,
-        transcript: &mut CashuTranscript,
     ) -> Result<bool, JsError> {
         let mintPublickey: MintPublicKey = MintPublicKey::fromJSON(mintPublickey)?;
         let coin: Coin = Coin::fromJSON(coin)?;
         let proof: ZKP = ZKP::fromJSON(proof)?;
-        Ok(IParamsProof::verify(
+        Ok(IssuanceProof::verify(
             &mintPublickey,
             &coin,
             proof,
-            transcript,
         ))
     }
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -215,11 +215,7 @@ impl IssuanceProof {
         let mintPublickey: MintPublicKey = MintPublicKey::fromJSON(mintPublickey)?;
         let coin: Coin = Coin::fromJSON(coin)?;
         let proof: ZKP = ZKP::fromJSON(proof)?;
-        Ok(IssuanceProof::verify(
-            &mintPublickey,
-            &coin,
-            proof,
-        ))
+        Ok(IssuanceProof::verify(&mintPublickey, &coin, proof))
     }
 }
 


### PR DESCRIPTION
The proof of issuance should be portable (included in future kvac tokens) and verifiable independently from other proofs. That is not possible if the Mint creates this using the same transcript as the other proofs.
For this reason, we internalize the creation of `CashuTranscript` in the case of the issuance proof.