### PR TITLE
refactor: remove `Coin` and `RandomizedCoin` -> `RandomizedCommitments`.

### DIFF
--- a/benches/misc_bench.rs
+++ b/benches/misc_bench.rs
@@ -51,6 +51,15 @@ fn bench_randomized_commitments_generation(bencher: &mut Bencher) {
         amount_attr.commitment(),
         Some(script_attr.commitment()),
         tag,
-    ).unwrap();
-    bencher.iter(|| RandomizedCommitments::from_attributes_and_mac(&amount_attr, Some(&script_attr), tag, mac, true));
+    )
+    .unwrap();
+    bencher.iter(|| {
+        RandomizedCommitments::from_attributes_and_mac(
+            &amount_attr,
+            Some(&script_attr),
+            tag,
+            mac,
+            true,
+        )
+    });
 }

--- a/benches/misc_bench.rs
+++ b/benches/misc_bench.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
 
 use cashu_kvac::{
-    models::{AmountAttribute, Coin, MintPrivateKey, RandomizedCoin, ScriptAttribute, MAC},
+    models::{AmountAttribute, MintPrivateKey, RandomizedCommitments, ScriptAttribute, MAC},
     secp::Scalar,
 };
 use test::Bencher;
@@ -29,27 +29,28 @@ fn bench_mac_generation(bencher: &mut Bencher) {
     let mint_privkey = privkey();
     let amount_attr = AmountAttribute::new(10, None);
     let script_attr = ScriptAttribute::new(b"3c83", None);
+    let tag = Scalar::random();
     bencher.iter(|| {
         MAC::generate(
             &mint_privkey,
-            &amount_attr.commitment(),
-            Some(&script_attr.commitment()),
-            None,
+            amount_attr.commitment(),
+            Some(script_attr.commitment()),
+            tag,
         )
     });
 }
 
 #[bench]
-fn bench_coin_randomization(bencher: &mut Bencher) {
+fn bench_randomized_commitments_generation(bencher: &mut Bencher) {
     let mint_privkey = privkey();
     let amount_attr = AmountAttribute::new(10, None);
     let script_attr = ScriptAttribute::new(b"3c83", None);
+    let tag = Scalar::random();
     let mac = MAC::generate(
         &mint_privkey,
-        &amount_attr.commitment(),
-        Some(&script_attr.commitment()),
-        None,
-    );
-    let coin = Coin::new(amount_attr, Some(script_attr), mac.unwrap());
-    bencher.iter(|| RandomizedCoin::from_coin(&coin, true));
+        amount_attr.commitment(),
+        Some(script_attr.commitment()),
+        tag,
+    ).unwrap();
+    bencher.iter(|| RandomizedCommitments::from_attributes_and_mac(&amount_attr, Some(&script_attr), tag, mac, true));
 }

--- a/benches/proofs_bench.rs
+++ b/benches/proofs_bench.rs
@@ -50,7 +50,8 @@ fn bench_mac_proof(bencher: &mut Bencher) {
     let mac = MAC::generate(&mint_privkey, amount_attr.commitment(), None, tag)
         .expect("Couldn't generate MAC");
     let randomized_commitments =
-        RandomizedCommitments::from_attributes_and_mac(&amount_attr, None, tag, mac, false).expect("Expected randomized commitments");
+        RandomizedCommitments::from_attributes_and_mac(&amount_attr, None, tag, mac, false)
+            .expect("Expected randomized commitments");
     bencher.iter(|| {
         MacProof::create(
             &mint_privkey.public_key,
@@ -113,9 +114,20 @@ fn bench_script_proofs(bencher: &mut Bencher) {
             .expect("MAC expected")
         })
         .collect();
-    let randomized_commitments: Vec<RandomizedCommitments> = tags.iter().zip(macs.iter()).zip(inputs.iter())
-        .map(|((tag, mac), attr)|
-            RandomizedCommitments::from_attributes_and_mac(&attr.0, Some(&attr.1), *tag, *mac, false).expect("RandomizedCommitments expected"))
+    let randomized_commitments: Vec<RandomizedCommitments> = tags
+        .iter()
+        .zip(macs.iter())
+        .zip(inputs.iter())
+        .map(|((tag, mac), attr)| {
+            RandomizedCommitments::from_attributes_and_mac(
+                &attr.0,
+                Some(&attr.1),
+                *tag,
+                *mac,
+                false,
+            )
+            .expect("RandomizedCommitments expected")
+        })
         .collect();
     bencher.iter(|| {
         ScriptEqualityProof::create(
@@ -165,7 +177,16 @@ fn bench_iparams_proof_verification(bencher: &mut Bencher) {
     let mac = MAC::generate(&mint_privkey, amount_attr.commitment(), None, tag)
         .expect("Couldn't generate MAC");
     let proof = IssuanceProof::create(&mint_privkey, tag, mac, amount_attr.commitment(), None);
-    bencher.iter(|| IssuanceProof::verify(&mint_privkey.public_key, tag, mac, &amount_attr, None, proof.clone()));
+    bencher.iter(|| {
+        IssuanceProof::verify(
+            &mint_privkey.public_key,
+            tag,
+            mac,
+            &amount_attr,
+            None,
+            proof.clone(),
+        )
+    });
 }
 
 #[bench]
@@ -187,9 +208,14 @@ fn bench_balance_proof_verification(bencher: &mut Bencher) {
         })
         .collect();
     let proof = BalanceProof::create(&inputs, &outputs, &mut client_transcript);
-    let randomized_commitments: Vec<RandomizedCommitments> = tags.iter().zip(macs.iter()).zip(inputs.iter())
-        .map(|((tag, mac), amount_attr)|
-            RandomizedCommitments::from_attributes_and_mac(amount_attr, None, *tag, *mac, false).expect("RandomizedCommitments expected"))
+    let randomized_commitments: Vec<RandomizedCommitments> = tags
+        .iter()
+        .zip(macs.iter())
+        .zip(inputs.iter())
+        .map(|((tag, mac), amount_attr)| {
+            RandomizedCommitments::from_attributes_and_mac(amount_attr, None, *tag, *mac, false)
+                .expect("RandomizedCommitments expected")
+        })
         .collect();
     let outputs: Vec<GroupElement> = outputs
         .into_iter()
@@ -215,7 +241,8 @@ fn bench_mac_proof_verification(bencher: &mut Bencher) {
     let mac = MAC::generate(&mint_privkey, amount_attr.commitment(), None, tag)
         .expect("Couldn't generate MAC");
     let randomized_commitments =
-        RandomizedCommitments::from_attributes_and_mac(&amount_attr, None, tag, mac, false).expect("Expected randomized commitments");
+        RandomizedCommitments::from_attributes_and_mac(&amount_attr, None, tag, mac, false)
+            .expect("Expected randomized commitments");
     let proof = MacProof::create(
         &mint_privkey.public_key,
         &amount_attr,
@@ -278,9 +305,20 @@ fn bench_script_proof_verification(bencher: &mut Bencher) {
             .expect("MAC expected")
         })
         .collect();
-    let randomized_commitments: Vec<RandomizedCommitments> = tags.iter().zip(macs.iter()).zip(inputs.iter())
-        .map(|((tag, mac), attr)|
-            RandomizedCommitments::from_attributes_and_mac(&attr.0, Some(&attr.1), *tag, *mac, false).expect("RandomizedCommitments expected"))
+    let randomized_commitments: Vec<RandomizedCommitments> = tags
+        .iter()
+        .zip(macs.iter())
+        .zip(inputs.iter())
+        .map(|((tag, mac), attr)| {
+            RandomizedCommitments::from_attributes_and_mac(
+                &attr.0,
+                Some(&attr.1),
+                *tag,
+                *mac,
+                false,
+            )
+            .expect("RandomizedCommitments expected")
+        })
         .collect();
     let proof = ScriptEqualityProof::create(
         &inputs,

--- a/src/kvac.rs
+++ b/src/kvac.rs
@@ -2,7 +2,7 @@ use crate::bulletproof::BulletProof;
 use crate::errors::Error;
 use crate::generators::{hash_to_curve, GENERATORS};
 use crate::models::{
-    AmountAttribute, Equation, MintPrivateKey, MintPublicKey, RandomizedCommitments, RangeZKP, ScriptAttribute, Statement, MAC, ZKP
+    AmountAttribute, Equation, MintPrivateKey, MintPublicKey, RandomizedCommitments, RangeZKP, ScriptAttribute, Statement, ZKP
 };
 use crate::secp::{GroupElement, Scalar, GROUP_ELEMENT_ZERO, SCALAR_ZERO};
 use crate::transcript::CashuTranscript;

--- a/src/kvac.rs
+++ b/src/kvac.rs
@@ -945,7 +945,7 @@ mod tests {
             })
             .collect();
         let proof = BalanceProof::create(&inputs, &outputs, &mut client_transcript);
-        let randomized_coms: Vec<RandomizedCommitments> = tags.iter().zip(macs.iter()).zip(outputs.iter())
+        let randomized_coms: Vec<RandomizedCommitments> = tags.iter().zip(macs.iter()).zip(inputs.iter())
             .map(|((tag, mac), amount_attr)|
                 RandomizedCommitments::from_attributes_and_mac(amount_attr, None, *tag, *mac, false).expect("RandomzedCommittment expected"))
             .collect();
@@ -966,7 +966,7 @@ mod tests {
     fn test_wrong_balance() {
         let (mut mint_transcript, mut client_transcript) = transcripts();
         let privkey = privkey();
-        let mut inputs = vec![
+        let inputs = vec![
             AmountAttribute::new(12, None),
             AmountAttribute::new(11, None),
         ];
@@ -981,7 +981,7 @@ mod tests {
             })
             .collect();
         let proof = BalanceProof::create(&inputs, &outputs, &mut client_transcript);
-        let randomized_coms: Vec<RandomizedCommitments> = tags.iter().zip(macs.iter()).zip(outputs.iter())
+        let randomized_coms: Vec<RandomizedCommitments> = tags.iter().zip(macs.iter()).zip(inputs.iter())
             .map(|((tag, mac), amount_attr)|
                 RandomizedCommitments::from_attributes_and_mac(amount_attr, None, *tag, *mac, false).expect("RandomzedCommittment expected"))
             .collect();
@@ -1036,7 +1036,7 @@ mod tests {
                 MAC::generate(&privkey, input.0.commitment(), Some(input.1.commitment()), *tag).expect("MAC expected")
             })
             .collect();
-        let randomized_coms: Vec<RandomizedCommitments> = tags.iter().zip(macs.iter()).zip(outputs.iter())
+        let randomized_coms: Vec<RandomizedCommitments> = tags.iter().zip(macs.iter()).zip(inputs.iter())
             .map(|((tag, mac), attr)|
                 RandomizedCommitments::from_attributes_and_mac(&attr.0, Some(&attr.1), *tag, *mac, false).expect("RandomzedCommittment expected"))
             .collect();
@@ -1097,7 +1097,7 @@ mod tests {
                 MAC::generate(&privkey, input.0.commitment(), Some(input.1.commitment()), *tag).expect("MAC expected")
             })
             .collect();
-        let randomized_coms: Vec<RandomizedCommitments> = tags.iter().zip(macs.iter()).zip(outputs.iter())
+        let randomized_coms: Vec<RandomizedCommitments> = tags.iter().zip(macs.iter()).zip(inputs.iter())
             .map(|((tag, mac), attr)|
                 RandomizedCommitments::from_attributes_and_mac(&attr.0, Some(&attr.1), *tag, *mac, false).expect("RandomzedCommittment expected"))
             .collect();

--- a/src/kvac.rs
+++ b/src/kvac.rs
@@ -298,8 +298,10 @@ impl MacProof {
     /// # Arguments
     ///
     /// * `mint_publickey` - A reference to the `MintPublicKey` used for generating the proof.
-    /// * `coin` - A reference to a `Coin` that contains the amount attribute and MAC.
-    /// * `randomized_coin` - A reference to a `RandomizedCoin` that contains the commitments needed for the proof.
+    /// * `amount_attribute` - A reference to an `AmountAttribute` containing the amount information.
+    /// * `script_attribute` - An optional reference to a `ScriptAttribute` containing script information.
+    /// * `tag` - A `Scalar` value representing the unique tag for the note.
+    /// * `randomized_commitments` - A reference to `RandomizedCommitments` that contains the commitments needed for the proof.
     /// * `transcript` - A mutable reference to a `CashuTranscript` that will be used during the proof creation.
     ///
     /// # Returns
@@ -338,7 +340,7 @@ impl MacProof {
     /// # Arguments
     ///
     /// * `mint_privkey` - A reference to the `MintPrivateKey` used for verification.
-    /// * `randomized_coin` - A reference to a `RandomizedCoin` that contains the commitments needed for verification.
+    /// * `randomized_commitments` - A reference to `RandomizedCommitments` that contains the commitments needed for verification.
     /// * `script` - An optional reference to a byte slice representing the script, if applicable.
     /// * `proof` - A `ZKP` instance containing the proof to be verified.
     /// * `transcript` - A mutable reference to a `CashuTranscript` that will be used during the verification.
@@ -443,9 +445,10 @@ impl IssuanceProof {
     /// # Arguments
     ///
     /// * `mint_privkey` - A reference to the `MintPrivateKey` used for generating the proof.
-    /// * `mac` - A reference to the `MAC` instance associated with the proof.
-    /// * `amount_commitment` - A reference to a `GroupElement` representing the amount commitment.
-    /// * `script_commitment` - An optional reference to a `GroupElement` representing the script commitment.
+    /// * `tag` - A `Scalar` value representing the unique tag for the note.
+    /// * `mac` - A `GroupElement` representing the MAC issued by the Mint.
+    /// * `amount_commitment` - A `GroupElement` representing the amount commitment.
+    /// * `script_commitment` - An optional `GroupElement` representing the script commitment.
     ///
     /// # Returns
     ///
@@ -474,14 +477,16 @@ impl IssuanceProof {
             .prove()
     }
 
-    /// Verifies the IParams proof against the provided parameters and transcript.
+    /// Verifies the IParams proof against the provided parameters.
     ///
     /// # Arguments
     ///
     /// * `mint_publickey` - A reference to the `MintPublicKey` used for verification.
-    /// * `coin` - A reference to a `Coin` that contains the MAC and amount attribute.
+    /// * `tag` - A `Scalar` value representing the unique tag for the note.
+    /// * `mac` - A `GroupElement` representing the MAC issued by the Mint.
+    /// * `amount_attribute` - A reference to an `AmountAttribute` containing the amount information.
+    /// * `script_attribute` - An optional reference to a `ScriptAttribute` containing script information.
     /// * `proof` - A `ZKP` instance containing the proof to be verified.
-    /// * `transcript` - A mutable reference to a `CashuTranscript` that will be used during the verification.
     ///
     /// # Returns
     ///
@@ -569,7 +574,7 @@ impl BalanceProof {
     /// Verifies a zero-knowledge proof for the balance of inputs and outputs.
     ///
     /// # Parameters
-    /// - `inputs`: A slice of `RandomizedCoin` with the randomized inputs to a transaction.
+    /// - `inputs`: A slice of `RandomizedCommitments` with the randomized inputs to a transaction.
     /// - `outputs`: A slice of `GroupElement` with the outputs to a transaction.
     /// - `delta_amount`: An integer representing the net change in amount (positive or negative).
     /// - `proof`: A `ZKP` representing the zero-knowledge balance proof to be verified.
@@ -610,7 +615,7 @@ impl ScriptEqualityProof {
     /// Creates a statement for the script equality proof based on the given inputs and outputs.
     ///
     /// # Parameters
-    /// - `inputs`: A slice of `RandomizedCoin` representing the randomized input coins.
+    /// - `inputs`: A slice of `RandomizedCommitments` representing the randomized input commitments.
     /// - `outputs`: A slice of tuples containing `GroupElement` commitments for amounts and scripts.
     ///
     /// # Returns
@@ -655,8 +660,8 @@ impl ScriptEqualityProof {
     /// Creates a zero-knowledge proof (ZKP) for the equality of scripts in the given inputs and outputs.
     ///
     /// # Parameters
-    /// - `inputs`: A slice of `Coin` representing the original input coins.
-    /// - `randomized_inputs`: A slice of `RandomizedCoin` representing the randomized input coins.
+    /// - `inputs`: A slice of tuples containing `AmountAttribute` and `ScriptAttribute` representing the original input attributes.
+    /// - `randomized_inputs`: A slice of `RandomizedCommitments` representing the randomized input commitments.
     /// - `outputs`: A slice of tuples containing `AmountAttribute` and `ScriptAttribute` for the outputs.
     /// - `transcript`: A mutable reference to a `CashuTranscript` used for the proof generation.
     ///
@@ -697,7 +702,7 @@ impl ScriptEqualityProof {
     /// Verifies a zero-knowledge proof for the equality of scripts in the given randomized inputs and outputs.
     ///
     /// # Parameters
-    /// - `randomized_inputs`: A slice of `RandomizedCoin` representing the randomized input coins.
+    /// - `randomized_inputs`: A slice of `RandomizedCommitments` representing the randomized input commitments.
     /// - `outputs`: A slice of tuples containing `GroupElement` commitments for amounts and scripts.
     /// - `proof`: A `ZKP` representing the zero-knowledge proof to be verified.
     /// - `transcript`: A mutable reference to a `CashuTranscript` used for the verification process.

--- a/src/models.rs
+++ b/src/models.rs
@@ -5,7 +5,7 @@ use crate::{
     bulletproof::BulletProof,
     errors::Error,
     generators::{hash_to_curve, GENERATORS},
-    secp::{GroupElement, Scalar, GROUP_ELEMENT_ZERO},
+    secp::{GroupElement, Scalar},
 };
 use bitcoin::hashes::sha256::Hash as Sha256Hash;
 use bitcoin::hashes::Hash;

--- a/src/models.rs
+++ b/src/models.rs
@@ -256,14 +256,14 @@ impl MAC {
     /// # Arguments
     ///
     /// * `privkey` - A reference to the `MintPrivateKey` used to generate the MAC.
-    /// * `amount_commitment` - A reference to a `GroupElement` representing the amount commitment.
-    /// * `script_commitment` - An optional reference to a `GroupElement` representing the script commitment.
-    ///   If not provided, a zero `GroupElement` is used.
-    /// * `tag` - A reference to a `Scalar` that will be used as a tag.
+    /// * `amount_commitment` - A `GroupElement` representing the amount commitment.
+    /// * `script_commitment` - An optional `GroupElement` representing the script commitment.
+    ///   If not provided, the origin `GroupElement` is used.
+    /// * `tag` - A `Scalar` that will be used as a unique tag for the note.
     ///
     /// # Returns
     ///
-    /// Returns a `Result<Self, Error>`, where `Self` is the newly generated `MAC` instance on success,
+    /// Returns a `Result<GroupElement, Error>`, where `GroupElement` is the newly generated MAC on success,
     /// or an `Error` if the MAC generation fails (e.g., if hashing to curve fails).
     #[allow(non_snake_case)]
     pub fn generate(
@@ -314,7 +314,10 @@ impl RandomizedCommitments {
     ///
     /// # Arguments
     ///
-    /// * `coin` - A reference to a `Coin` instance from which the randomized coin will be created.
+    /// * `amount_attribute` - A reference to an `AmountAttribute` containing the amount information.
+    /// * `script_attribute` - An optional reference to a `ScriptAttribute` containing script information.
+    /// * `tag` - A `Scalar` value representing the unique tag for the note.
+    /// * `mac` - A `GroupElement` representing the MAC issued by the Mint.
     /// * `reveal_script` - A boolean indicating whether the script inside the `ScriptAttribute`
     ///   will be revealed. If true, the randomized script commitment will be void,
     ///   leaving space for the Mint to "fill in" the blank with the hash of the
@@ -322,8 +325,8 @@ impl RandomizedCommitments {
     ///
     /// # Returns
     ///
-    /// Returns a `Result<Self, Error>`, where `Self` is the newly created `RandomizedCoin` instance
-    /// on success, or an `Error` if the creation of the randomized coin fails (e.g., if hashing to
+    /// Returns a `Result<Self, Error>`, where `Self` is the newly created `RandomizedCommitments` instance
+    /// on success, or an `Error` if the creation of the randomized commitments fails (e.g., if hashing to
     /// curve fails).
     #[allow(non_snake_case)]
     pub fn from_attributes_and_mac(

--- a/src/models.rs
+++ b/src/models.rs
@@ -331,7 +331,7 @@ impl RandomizedCommitments {
         script_attribute: Option<&ScriptAttribute>,
         tag: Scalar,
         mac: GroupElement,
-        reveal_script: bool
+        reveal_script: bool,
     ) -> Result<Self, Error> {
         let t = tag;
         let V = mac;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -10,8 +10,7 @@ use crate::{
     bulletproof::BulletProof,
     kvac::{BalanceProof, BootstrapProof, IssuanceProof, MacProof, ScriptEqualityProof},
     models::{
-        AmountAttribute, MintPrivateKey, MintPublicKey, RandomizedCommitments, ScriptAttribute,
-        ZKP,
+        AmountAttribute, MintPrivateKey, MintPublicKey, RandomizedCommitments, ScriptAttribute, ZKP,
     },
     secp::{GroupElement, Scalar},
     transcript::CashuTranscript,
@@ -99,12 +98,23 @@ impl ScriptAttribute {
 
 #[wasm_bindgen]
 impl RandomizedCommitments {
-    pub fn wasmFromAttributesAndMac(amountAttr: JsValue, scriptAttr: JsValue, tag: JsValue, mac: JsValue, revealScript: bool) -> Result<JsValue, JsError> {
+    pub fn wasmFromAttributesAndMac(
+        amountAttr: JsValue,
+        scriptAttr: JsValue,
+        tag: JsValue,
+        mac: JsValue,
+        revealScript: bool,
+    ) -> Result<JsValue, JsError> {
         let amountAttr: AmountAttribute = AmountAttribute::fromJSON(amountAttr)?;
-        let scriptAttr: Option<ScriptAttribute> = from_value(scriptAttr).map_err(|e| JsError::new(&format!("{e}")))?;
+        let scriptAttr: Option<ScriptAttribute> =
+            from_value(scriptAttr).map_err(|e| JsError::new(&format!("{e}")))?;
         let tag: Scalar = Scalar::fromJSON(tag)?;
         let mac: GroupElement = GroupElement::fromJSON(mac)?;
-        Ok(Self::from_attributes_and_mac(&amountAttr, scriptAttr.as_ref(), tag, mac, revealScript).unwrap().toJSON())
+        Ok(
+            Self::from_attributes_and_mac(&amountAttr, scriptAttr.as_ref(), tag, mac, revealScript)
+                .unwrap()
+                .toJSON(),
+        )
     }
 }
 
@@ -142,9 +152,19 @@ impl MacProof {
         let mintPubkey: MintPublicKey = MintPublicKey::fromJSON(mintPublickey)?;
         let amountAttr: AmountAttribute = AmountAttribute::fromJSON(amountAttribute)?;
         let tag: Scalar = Scalar::fromJSON(tag)?;
-        let randomizedComms: RandomizedCommitments = RandomizedCommitments::fromJSON(randomizedCoin)?;
-        let scriptAttr: Option<ScriptAttribute> = from_value(scriptAttribute).map_err(|e| JsError::new(&format!("{e}")))?;
-        Ok(MacProof::create(&mintPubkey, &amountAttr, scriptAttr.as_ref(), tag, &randomizedComms, transcript).toJSON())
+        let randomizedComms: RandomizedCommitments =
+            RandomizedCommitments::fromJSON(randomizedCoin)?;
+        let scriptAttr: Option<ScriptAttribute> =
+            from_value(scriptAttribute).map_err(|e| JsError::new(&format!("{e}")))?;
+        Ok(MacProof::create(
+            &mintPubkey,
+            &amountAttr,
+            scriptAttr.as_ref(),
+            tag,
+            &randomizedComms,
+            transcript,
+        )
+        .toJSON())
     }
 
     pub fn wasmVerify(
@@ -155,7 +175,8 @@ impl MacProof {
         transcript: &mut CashuTranscript,
     ) -> Result<bool, JsError> {
         let mintPrivkey: MintPrivateKey = MintPrivateKey::fromJSON(mintPrivkey)?;
-        let randomizedCoin: RandomizedCommitments = RandomizedCommitments::fromJSON(randomizedCoin)?;
+        let randomizedCoin: RandomizedCommitments =
+            RandomizedCommitments::fromJSON(randomizedCoin)?;
         let proof: ZKP = ZKP::fromJSON(proof)?;
         match script {
             None => Ok(MacProof::verify(
@@ -191,14 +212,10 @@ impl IssuanceProof {
         let amountCommitment: GroupElement = GroupElement::fromJSON(amountCommitment)?;
         let scriptCommitment: Option<GroupElement> =
             from_value(scriptCommitment).map_err(|e| JsError::new(&format!("{e}")))?;
-        Ok(IssuanceProof::create(
-            &mintPrivkey,
-            tag,
-            mac,
-            amountCommitment,
-            scriptCommitment,
+        Ok(
+            IssuanceProof::create(&mintPrivkey, tag, mac, amountCommitment, scriptCommitment)
+                .toJSON(),
         )
-        .toJSON())
     }
 
     pub fn wasmVerify(
@@ -211,11 +228,19 @@ impl IssuanceProof {
     ) -> Result<bool, JsError> {
         let mintPublickey: MintPublicKey = MintPublicKey::fromJSON(mintPublickey)?;
         let amountAttr = AmountAttribute::fromJSON(amountAttr)?;
-        let scriptAttr: Option<ScriptAttribute> = from_value(scriptAttr).map_err(|e| JsError::new(&format!("{e}")))?;
+        let scriptAttr: Option<ScriptAttribute> =
+            from_value(scriptAttr).map_err(|e| JsError::new(&format!("{e}")))?;
         let mac = GroupElement::fromJSON(mac)?;
         let tag = Scalar::fromJSON(tag)?;
         let proof: ZKP = ZKP::fromJSON(proof)?;
-        Ok(IssuanceProof::verify(&mintPublickey, tag, mac, &amountAttr, scriptAttr.as_ref(), proof))
+        Ok(IssuanceProof::verify(
+            &mintPublickey,
+            tag,
+            mac,
+            &amountAttr,
+            scriptAttr.as_ref(),
+            proof,
+        ))
     }
 }
 
@@ -265,7 +290,8 @@ impl ScriptEqualityProof {
     ) -> Result<JsValue, JsError> {
         let outputs: Vec<(AmountAttribute, ScriptAttribute)> =
             from_value(outputs).map_err(|e| JsError::new(&format!("{e}")))?;
-        let inputs: Vec<(AmountAttribute, ScriptAttribute)> = from_value(inputs).map_err(|e| JsError::new(&format!("{e}")))?;
+        let inputs: Vec<(AmountAttribute, ScriptAttribute)> =
+            from_value(inputs).map_err(|e| JsError::new(&format!("{e}")))?;
         let randomizedInputs: Vec<RandomizedCommitments> =
             from_value(randomizedInputs).map_err(|e| JsError::new(&format!("{e}")))?;
         Ok(
@@ -277,7 +303,7 @@ impl ScriptEqualityProof {
 
     pub fn wasmVerify(
         randomizedInputs: JsValue, //Vec<RandomizedCommitments>
-        outputs: JsValue, //Vec<(GroupElement, GroupElement)>,
+        outputs: JsValue,          //Vec<(GroupElement, GroupElement)>,
         proof: JsValue,
         transcript: &mut CashuTranscript,
     ) -> Result<bool, JsError> {


### PR DESCRIPTION
`MAC`, `Coin` and `RandomizedCoin` resulted in a useless nesting with the types on the actual Mint implementation. It's just better **NOT TO** encapsulate into (t, V) in `MAC` and then encapsulate `MAC` and `AmountAttribute` and `ScriptAttribute` into `Coin`.