### PR TITLE
add `get_nullifier` method to `RandomizedCommitments`

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -367,6 +367,10 @@ impl RandomizedCommitments {
             Cv,
         })
     }
+
+    pub fn get_nullifier(&self) -> GroupElement {
+        self.Cv
+    }
 }
 
 /// Structure that holds information about an equation to be proven


### PR DESCRIPTION
Add an easy and safer way to get an identifier of `RandomizedCommitments`