### PR TITLE
wip: sharp range proof (relaxed soundness)

### DIFF
--- a/src/bulletproof.rs
+++ b/src/bulletproof.rs
@@ -79,7 +79,7 @@ fn pad_ones(mut l: Vec<Scalar>, to: usize) -> Vec<Scalar> {
 fn inner_product(l: &[Scalar], r: &[Scalar]) -> Scalar {
     let mut result = Scalar::from(0);
     for (left, right) in l.iter().zip(r.iter()) {
-        result = result + (*left * right).as_ref();
+        result += (*left * right).as_ref();
     }
     result
 }
@@ -137,7 +137,7 @@ impl InnerProductArgument {
                 b[n..].iter(),
                 H_[..n].iter()
             ) {
-                L = L + &(*G_i * a_i + &(*H_i * b_i))
+                L += &(*G_i * a_i + &(*H_i * b_i))
             }
             let mut R = U_ * &c_right;
             for (a_i, G_i, b_i, H_i) in izip!(
@@ -146,7 +146,7 @@ impl InnerProductArgument {
                 b[..n].iter(),
                 H_[n..2 * n].iter()
             ) {
-                R = R + &(*G_i * a_i + &(*H_i * b_i))
+                R += &(*G_i * a_i + &(*H_i * b_i))
             }
 
             // Prover -> Verifier : L, R
@@ -224,7 +224,7 @@ impl InnerProductArgument {
         // Switch generator U
         let U_ = U_ * &tetha;
         // Tweak commitment P
-        P = P + &(U_ * &c);
+        P += &(U_ * &c);
         // ## END PROTOCOL 1 ##
 
         // ## PROTOCOL 2 ##
@@ -349,7 +349,7 @@ impl BulletProof {
             a_right.iter(),
             H_.clone().into_iter()
         ) {
-            A = A + &(G_i * a_l_i + &(H_i * a_r_i));
+            A += &(G_i * a_l_i + &(H_i * a_r_i));
         }
 
         // s_l and s_r are the bits commitment blinding vectors
@@ -367,7 +367,7 @@ impl BulletProof {
             s_r.iter(),
             H_.clone().into_iter()
         ) {
-            S = S + &(G_i * s_l_i + &(H_i * s_r_i));
+            S += &(G_i * s_l_i + &(H_i * s_r_i));
         }
 
         // Prover -> Verifier: A, S
@@ -402,8 +402,7 @@ impl BulletProof {
 
         let mut delta_y_z = Scalar::new(&SCALAR_ZERO);
         for (i, y_i) in y_list.iter().enumerate() {
-            delta_y_z =
-                delta_y_z + &(p * y_i + &(z_list[3] * &z_list[i / n] * &POWERS_OF_TWO[i % n]));
+            delta_y_z += &(p * y_i + &(z_list[3] * &z_list[i / n] * &POWERS_OF_TWO[i % n]));
         }
 
         // l(X) and r(X) linear vector polynomials   (70-71)
@@ -470,7 +469,7 @@ impl BulletProof {
         let mut tau_0 = Scalar::new(&SCALAR_ZERO);
         let z_2 = z_list[2];
         for (attribute_pair, z_j) in izip!(attributes.iter(), z_list.into_iter()) {
-            tau_0 = tau_0 + &(z_j * &attribute_pair.r);
+            tau_0 += &(z_j * &attribute_pair.r);
         }
         tau_0 = tau_0 * &z_2;
         let tau_x = tau_0 + &(tau_1 * &x) + &(tau_2 * &x_2);
@@ -584,8 +583,7 @@ impl BulletProof {
 
         let mut delta_y_z = Scalar::new(&SCALAR_ZERO);
         for (i, y_i) in y_list.iter().enumerate() {
-            delta_y_z =
-                delta_y_z + &(p * y_i + &(z_list[3] * &z_list[i / n] * &POWERS_OF_TWO[i % n]));
+            delta_y_z += &(p * y_i + &(z_list[3] * &z_list[i / n] * &POWERS_OF_TWO[i % n]));
         }
 
         // Prover -> Verifier: T_1, T_2
@@ -605,7 +603,7 @@ impl BulletProof {
         // Check that t_x = t(x) = t_0 + t_1*x + t_2*x^2     (72)
         let mut V_z_m = GENERATORS.O;
         for (commitment_pair, z_j) in izip!(attribute_commitments.iter(), z_list.iter()) {
-            V_z_m = V_z_m + &(*commitment_pair * z_j);
+            V_z_m += &(*commitment_pair * z_j);
         }
         if GENERATORS.G_amount * &t_x + &(GENERATORS.G_blind * &tau_x)
             != V_z_m * &z_list[2] + &(GENERATORS.G_amount * &delta_y_z) + &(T1 * &x) + &(T2 * &x_2)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,6 +22,19 @@ pub enum Error {
     ScalarZero,
     #[error("Cannot instantiate GroupElement from hex string zero")]
     GroupElementZero,
+
+    /// Sharp errors
+    #[error("Parameter setup failed")]
+    ParameterSetupFailure,
+    #[error("Maximum allowed range for range-proof is invalid")]
+    InvalidRangeBound,
+    #[error("Positive integer not representable with a 3-square sum")]
+    ThreeSquaresFailure,
+    #[error("Attribute value is out of range")]
+    OutOfRangeError,
+    #[error("Short masking failed")]
+    MaskingFailure,
+
     /// Secp256k1 error
     #[error(transparent)]
     Secp256k1(#[from] secp256k1::Error),

--- a/src/kvac.rs
+++ b/src/kvac.rs
@@ -68,7 +68,7 @@ impl<'a> SchnorrProver<'a> {
 
             for row in equation.take_rhs().into_iter() {
                 for (k, P) in self.random_terms.iter().zip(row.into_iter()) {
-                    R = R + (P * k).as_ref();
+                    R += (P * k).as_ref();
                 }
             }
 
@@ -144,7 +144,7 @@ impl<'a> SchnorrVerifier<'a> {
 
             for row in equation.take_rhs().into_iter() {
                 for (s, P) in self.responses.iter().zip(row.into_iter()) {
-                    R = R + (P * s).as_ref();
+                    R += (P * s).as_ref();
                 }
             }
             R = R - (V * self.challenge.as_ref()).as_ref();
@@ -556,11 +556,11 @@ impl BalanceProof {
     ) -> ZKP {
         let mut r_sum = Scalar::new(&SCALAR_ZERO);
         for input in inputs.iter() {
-            r_sum = r_sum + &input.r;
+            r_sum += &input.r;
         }
         let mut r_sum_ = Scalar::new(&SCALAR_ZERO);
         for output in outputs.iter() {
-            r_sum_ = r_sum_ + &output.r;
+            r_sum_ += &output.r;
         }
         let delta_r = (-r_sum_) + r_sum.as_ref();
         let B = GENERATORS.Gz_attribute * r_sum.as_ref()
@@ -595,7 +595,7 @@ impl BalanceProof {
             B.negate();
         }
         for input in inputs.iter() {
-            B = B + input.Ca.as_ref();
+            B += input.Ca.as_ref();
         }
         for output in outputs.iter() {
             B = B - output;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,6 @@ pub mod kvac;
 pub mod models;
 pub mod recovery;
 pub mod secp;
+pub mod sharp;
 pub mod transcript;
 pub mod wasm;
-pub mod sharp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,3 +7,4 @@ pub mod recovery;
 pub mod secp;
 pub mod transcript;
 pub mod wasm;
+pub mod sharp;

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -55,7 +55,7 @@ pub fn recover_amounts(
     let one = GENERATORS.G_amount;
 
     for j in 1..m {
-        index = index + &one;
+        index += &one;
         table.insert(index, j);
     }
 
@@ -73,10 +73,10 @@ pub fn recover_amounts(
                     a = Some(i * m + j);
                     break;
                 }
-                None => A = A + &G_m_inv,
+                // Add up all G_m_inv values
+                None => A += &G_m_inv,
             }
         }
-
         recovered_amounts.push(a);
     }
 

--- a/src/secp.rs
+++ b/src/secp.rs
@@ -435,6 +435,13 @@ impl std::ops::Add<&Scalar> for Scalar {
     }
 }
 
+impl std::ops::AddAssign<&Scalar> for Scalar {
+
+    fn add_assign(&mut self, rhs: &Scalar) {
+        self.tweak_add(rhs);
+    }
+}
+
 impl std::ops::Neg for Scalar {
     type Output = Scalar;
 
@@ -608,6 +615,12 @@ impl std::ops::Add<&GroupElement> for GroupElement {
     fn add(mut self, other: &GroupElement) -> GroupElement {
         self.combine_add(other);
         self
+    }
+}
+
+impl std::ops::AddAssign<&GroupElement> for GroupElement {
+    fn add_assign(&mut self, rhs: &GroupElement) {
+        self.combine_add(&rhs);
     }
 }
 

--- a/src/secp.rs
+++ b/src/secp.rs
@@ -436,7 +436,6 @@ impl std::ops::Add<&Scalar> for Scalar {
 }
 
 impl std::ops::AddAssign<&Scalar> for Scalar {
-
     fn add_assign(&mut self, rhs: &Scalar) {
         self.tweak_add(rhs);
     }

--- a/src/secp.rs
+++ b/src/secp.rs
@@ -619,7 +619,7 @@ impl std::ops::Add<&GroupElement> for GroupElement {
 
 impl std::ops::AddAssign<&GroupElement> for GroupElement {
     fn add_assign(&mut self, rhs: &GroupElement) {
-        self.combine_add(&rhs);
+        self.combine_add(rhs);
     }
 }
 

--- a/src/secp.rs
+++ b/src/secp.rs
@@ -537,6 +537,18 @@ impl From<u64> for Scalar {
     }
 }
 
+impl TryFrom<&BigInt> for Scalar {
+    type Error = Error;
+    fn try_from(value: &BigInt) -> Result<Self, Error> {
+        let (_, mut value_bytes) = value.to_bytes_le();
+        if value_bytes.len() < 32 {
+            value_bytes.resize(32, 0u8);
+        }
+        value_bytes.reverse();
+        Ok(Scalar::new(&value_bytes))
+    }
+}
+
 impl TryFrom<&str> for Scalar {
     type Error = Error;
     fn try_from(hex_string: &str) -> Result<Self, Error> {

--- a/src/sharp.rs
+++ b/src/sharp.rs
@@ -8,7 +8,7 @@ use crate::{
     secp::{GroupElement, Scalar, SCALAR_ZERO},
     transcript::CashuTranscript,
 };
-use bitcoin::{amount, secp256k1::constants::CURVE_ORDER};
+use bitcoin::secp256k1::constants::CURVE_ORDER;
 use num_traits::Zero;
 
 pub fn find_3_squares(value: u64) -> Result<(u64, u64, u64), Error> {
@@ -122,7 +122,7 @@ impl SharpPOSO {
     ) -> Result<Self, Error> {
         // MARK: - PARAMETERS SETUP
         // We use the same group for short opening and decomposition
-        if amount_attributes.len() == 0 {
+        if amount_attributes.is_empty() {
             return Err(Error::EmptyList);
         }
         // N is the number of attributes to prove the range of
@@ -171,13 +171,13 @@ impl SharpPOSO {
                 if z > (((V + 1) * L) + 1) {
                     return Err(Error::MaskingFailure);
                 }
-                Ok(Scalar::try_from(&z)?)
+                Scalar::try_from(&z)
             };
 
         let get_mask = |V: &BigInt, L: &BigInt| -> Result<Scalar, Error> {
             let nonce = Scalar::random();
             let r = (BigInt::from_be_bytes(&nonce.to_bytes())) % (((V + 1) * L) + 1);
-            Ok(Scalar::try_from(&r)?)
+            Scalar::try_from(&r)
         };
 
         transcript.domain_sep(b"SharpPOSO_Statement_");
@@ -193,7 +193,7 @@ impl SharpPOSO {
         let x_list: Vec<Scalar> = amount_attributes.iter().map(|att| att.a).collect();
         let r_x_list: Vec<Scalar> = amount_attributes.iter().map(|att| att.r).collect();
         for C_x_i in C_x_list.iter() {
-            transcript.append_element(b"C_x_i", &C_x_i);
+            transcript.append_element(b"C_x_i", C_x_i);
         }
 
         // (Algorithm 2, Phase 1, line 1)
@@ -467,7 +467,7 @@ impl SharpPOSO {
     ) -> bool {
         // MARK: - PARAMETERS SETUP
         // We use the same group for short opening and decomposition
-        if amount_commitments.len() == 0 {
+        if amount_commitments.is_empty() {
             return false;
         }
         // N is the number of attributes to prove the range of
@@ -538,7 +538,7 @@ impl SharpPOSO {
             return false;
         }
 
-        let upper_bound = 4 * &N * &B * &Y;
+        let upper_bound = 4 * N * B * Y;
         for zeta_k in self.zeta_list.iter() {
             // 𝛇_k ≤ (4·N·B·Y + 1)L_x
             if BigInt::from_be_bytes(&zeta_k.to_bytes()) > upper_bound {

--- a/src/sharp.rs
+++ b/src/sharp.rs
@@ -1,7 +1,12 @@
 use num_bigint::BigInt;
 use num_traits::FromBytes;
 
-use crate::{ errors::Error, generators::{hash_to_curve, GENERATORS}, models::AmountAttribute, secp::{GroupElement, Scalar, SCALAR_ZERO}, transcript::CashuTranscript
+use crate::{
+    errors::Error,
+    generators::{hash_to_curve, GENERATORS},
+    models::AmountAttribute,
+    secp::{GroupElement, Scalar, SCALAR_ZERO},
+    transcript::CashuTranscript,
 };
 use bitcoin::{amount, secp256k1::constants::CURVE_ORDER};
 use num_traits::Zero;
@@ -29,22 +34,28 @@ pub fn find_3_squares(value: u64) -> Result<(u64, u64, u64), Error> {
     let vmax = (value as f64).sqrt() as u64;
     for x in 0..=vmax {
         let x2 = (x as u128) * (x as u128);
-        if x2 > value as u128 { break; }
+        if x2 > value as u128 {
+            break;
+        }
         let rem1 = value as u128 - x2;
         let ymax = (rem1 as f64).sqrt() as u64;
         for y in x..=ymax {
             let y2 = (y as u128) * (y as u128);
-            if y2 > rem1 { break; }
+            if y2 > rem1 {
+                break;
+            }
             let rem2 = rem1 - y2;
             // check if rem2 is a perfect square
             let z = (rem2 as f64).sqrt() as u64;
-            for candidate_z in z..=z+1 {
+            for candidate_z in z..=z + 1 {
                 let z2 = (candidate_z as u128) * (candidate_z as u128);
                 if z2 == rem2 {
                     // return sorted tuple (x,y,z) where x<=y<=z
                     return Ok((x, y, candidate_z));
                 }
-                if z2 > rem2 { break; }
+                if z2 > rem2 {
+                    break;
+                }
             }
         }
     }
@@ -55,26 +66,32 @@ pub fn find_3_squares(value: u64) -> Result<(u64, u64, u64), Error> {
 }
 
 fn get_rast_3dec_generators(n: u64) -> Vec<GroupElement> {
-    (0..n*3).map(|m| {
-        let j = m % 3;
-        let i = m / 3;
-        hash_to_curve(format!("CASHU_SHARP_RAST_3DEC_{i}_{j}").as_bytes())
+    (0..n * 3)
+        .map(|m| {
+            let j = m % 3;
+            let i = m / 3;
+            hash_to_curve(format!("CASHU_SHARP_RAST_3DEC_{i}_{j}").as_bytes())
                 .expect("Couldn't map hash to point on the curve")
-    }).collect()
+        })
+        .collect()
 }
 
 fn get_rast_3dec_masks_generators(n: u64) -> Vec<GroupElement> {
-    (0..n+1).map(|m| {
-        hash_to_curve(format!("CASHU_SHARP_RAST_3DEC_MASKS_{m}").as_bytes())
+    (0..n + 1)
+        .map(|m| {
+            hash_to_curve(format!("CASHU_SHARP_RAST_3DEC_MASKS_{m}").as_bytes())
                 .expect("Couldn't map hash to point on the curve")
-    }).collect()
+        })
+        .collect()
 }
 
 fn get_generators_second_phase(n: u64) -> Vec<GroupElement> {
-    (0..n+1).map(|m| {
-        hash_to_curve(format!("CASHU_SHARP_OPENINGS_{m}").as_bytes())
+    (0..n + 1)
+        .map(|m| {
+            hash_to_curve(format!("CASHU_SHARP_OPENINGS_{m}").as_bytes())
                 .expect("Couldn't map hash to point on the curve")
-    }).collect()
+        })
+        .collect()
 }
 #[allow(non_snake_case)]
 pub struct SharpPOSO {
@@ -104,7 +121,7 @@ impl SharpPOSO {
         range_max: u64,
     ) -> Result<Self, Error> {
         // MARK: - PARAMETERS SETUP
-        // We use the same group for short opening and decomposition   
+        // We use the same group for short opening and decomposition
         if amount_attributes.len() == 0 {
             return Err(Error::EmptyList);
         }
@@ -112,11 +129,11 @@ impl SharpPOSO {
         let N = amount_attributes.len() as u64;
 
         if range_max == 0 {
-            return Err(Error::InvalidRangeBound)
+            return Err(Error::InvalidRangeBound);
         }
         let B = range_max;
         let P = BigInt::from_be_bytes(&CURVE_ORDER);
-        
+
         // Y is the challenge space size. For exact [0, B] membership, Y < 4B
         let Y = BigInt::from(4 * B - 1);
         // R is the number of repetitions. It must be that (Y + 1)^R - 1 <= CURVE_ORDER
@@ -131,51 +148,53 @@ impl SharpPOSO {
         // L_x is the masking overhead for the short witnesses
         // 18((B·Y+1)·L_x)^2 ≤ SECP256K1_ORDER
         let mut L_x = BigInt::from(1);
-        tmp = (B*&Y+1) * &L_x;
+        tmp = (B * &Y + 1) * &L_x;
         tmp.pow(2);
         tmp *= 18;
         while tmp <= P {
             L_x <<= 1;
-            tmp = (B*&Y+1) * &L_x;
+            tmp = (B * &Y + 1) * &L_x;
             tmp.pow(2);
             tmp *= 18;
         }
         L_x >>= 1;
 
         if L_x.is_zero() {
-            return Err(Error::ParameterSetupFailure)
+            return Err(Error::ParameterSetupFailure);
         }
 
-        let apply_mask = |value: Scalar, mask: Scalar, V: &BigInt, L: &BigInt| -> Result<Scalar, Error> {
-            let r = (BigInt::from_be_bytes(&mask.to_bytes())) % (((V + 1)*L) + 1);
-            let v = BigInt::from_be_bytes(&value.to_bytes());
-            let z = v + r;
-            if z > (((V + 1)*L) + 1) {
-                return Err(Error::MaskingFailure);
-            }
-            Ok(Scalar::try_from(&z)?)
-        };
+        let apply_mask =
+            |value: Scalar, mask: Scalar, V: &BigInt, L: &BigInt| -> Result<Scalar, Error> {
+                let r = (BigInt::from_be_bytes(&mask.to_bytes())) % (((V + 1) * L) + 1);
+                let v = BigInt::from_be_bytes(&value.to_bytes());
+                let z = v + r;
+                if z > (((V + 1) * L) + 1) {
+                    return Err(Error::MaskingFailure);
+                }
+                Ok(Scalar::try_from(&z)?)
+            };
 
         let get_mask = |V: &BigInt, L: &BigInt| -> Result<Scalar, Error> {
             let nonce = Scalar::random();
-            let r = (BigInt::from_be_bytes(&nonce.to_bytes())) % (((V + 1)*L) + 1);
+            let r = (BigInt::from_be_bytes(&nonce.to_bytes())) % (((V + 1) * L) + 1);
             Ok(Scalar::try_from(&r)?)
         };
 
         transcript.domain_sep(b"SharpPOSO_Statement_");
 
-
         // MARK: - PHASE 1
 
         // A list with all the amount commitments C_x_i = [C_x_0, C_x_1, ...]
         // A list with all the blinding factors r_x_i = [r_x_0, r_x_1, ...]
-        let C_x_list: Vec<GroupElement> = amount_attributes.iter().map(|att| att.commitment()).collect();
+        let C_x_list: Vec<GroupElement> = amount_attributes
+            .iter()
+            .map(|att| att.commitment())
+            .collect();
         let x_list: Vec<Scalar> = amount_attributes.iter().map(|att| att.a).collect();
         let r_x_list: Vec<Scalar> = amount_attributes.iter().map(|att| att.r).collect();
         for C_x_i in C_x_list.iter() {
             transcript.append_element(b"C_x_i", &C_x_i);
         }
-        
 
         // (Algorithm 2, Phase 1, line 1)
         // For each attribute's amount a_i, find y_(i,1), y_(i,2), y_(i,3)
@@ -196,20 +215,19 @@ impl SharpPOSO {
         let rast_3dec_generators = get_rast_3dec_generators(N);
         let r_y = Scalar::random();
 
-
         let mut C_y = GENERATORS.G_blind * &r_y;
         for i in 0..N {
-            let y_1 = y_list[(i*3) as usize];
-            let y_2 = y_list[(i*3+1) as usize];
-            let y_3 = y_list[(i*3+2) as usize];
-            C_y += &((rast_3dec_generators[(3*i) as usize] * &y_1)
-                + &(rast_3dec_generators[(3*i+1) as usize] * &y_2)
-                + &(rast_3dec_generators[(3*i+2) as usize] * &y_3))
+            let y_1 = y_list[(i * 3) as usize];
+            let y_2 = y_list[(i * 3 + 1) as usize];
+            let y_3 = y_list[(i * 3 + 2) as usize];
+            C_y += &((rast_3dec_generators[(3 * i) as usize] * &y_1)
+                + &(rast_3dec_generators[(3 * i + 1) as usize] * &y_2)
+                + &(rast_3dec_generators[(3 * i + 2) as usize] * &y_3))
         }
         let mu_list: Vec<Scalar>;
         let gamma_list: Vec<Scalar>;
         let zeta_list: Vec<Scalar>;
-        let R_x = 4*N*B*&Y;
+        let R_x = 4 * N * B * &Y;
 
         // Masking can succeed with probability 1-1/(L+1), and (1-1/(L+1))^R over all R repetitions
         // Therefore, we should be looking at the following probability of failure at iteration i of this loop:
@@ -221,33 +239,36 @@ impl SharpPOSO {
             let mut tmp_transcript = transcript.clone();
             let mut tmp_C_y = C_y;
 
-            let mut tmp_mu_list: Vec<Scalar> = vec![];           
+            let mut tmp_mu_list: Vec<Scalar> = vec![];
             for i in 0..R {
                 let mu_k = get_mask(&R_x, &L_x)?;
 
                 tmp_C_y += &(rast_3dec_masks_generators[i as usize] * &mu_k);
                 tmp_mu_list.push(mu_k);
             }
-            
+
             tmp_transcript.append_element(b"C_y", &tmp_C_y);
 
             // Get short challenges for every integer in the sq-decomp, for every x in the batch,
             // for every k in the repetitions R
-            let tmp_gamma_list: Vec<Scalar> = (0..4*N*R).map(|_| {
-                let big_chall = BigInt::from_be_bytes(&tmp_transcript.get_challenge(b"short_chall").to_bytes());
-                Scalar::try_from(&(big_chall % &Y)) // short chall
-            }
-            ).collect::<Result<Vec<Scalar>, Error>>()?;
-            
+            let tmp_gamma_list: Vec<Scalar> = (0..4 * N * R)
+                .map(|_| {
+                    let big_chall = BigInt::from_be_bytes(
+                        &tmp_transcript.get_challenge(b"short_chall").to_bytes(),
+                    );
+                    Scalar::try_from(&(big_chall % &Y)) // short chall
+                })
+                .collect::<Result<Vec<Scalar>, Error>>()?;
+
             let mut shortness_failure = false;
             let mut tmp_zeta_list: Vec<Scalar> = vec![];
             for k in 0..R {
                 let mut sum = Scalar::new(&SCALAR_ZERO);
                 for i in 0..N {
                     for j in 0..4 {
-                        let gamma_index = k*N*4 + i*4 + j;
+                        let gamma_index = k * N * 4 + i * 4 + j;
                         let gamma_ijk = tmp_gamma_list[gamma_index as usize];
-                        let y_ij = y_list[(i*4 + j) as usize];
+                        let y_ij = y_list[(i * 4 + j) as usize];
                         sum += &(y_ij * &gamma_ijk);
                     }
                 }
@@ -255,10 +276,13 @@ impl SharpPOSO {
                 let masked_sum = apply_mask(sum, tmp_mu_list[k as usize], &R_x, &L_x);
                 match masked_sum {
                     Ok(m) => tmp_zeta_list.push(m),
-                    Err(Error::MaskingFailure) => { shortness_failure = true; break; },
-                    Err(e) => return Err(e)
+                    Err(Error::MaskingFailure) => {
+                        shortness_failure = true;
+                        break;
+                    }
+                    Err(e) => return Err(e),
                 };
-            };
+            }
 
             // If we get a masking failure, retry.
             if shortness_failure {
@@ -273,11 +297,13 @@ impl SharpPOSO {
             zeta_list = tmp_zeta_list;
 
             transcript.append_element(b"C_y", &C_y);
-            (0..4*N*R).for_each(|_| { transcript.get_challenge(b"short_chall"); });
+            (0..4 * N * R).for_each(|_| {
+                transcript.get_challenge(b"short_chall");
+            });
 
             break;
         }
-        
+
         // ### END PHASE 1 ###
 
         // MARK: - PHASE 2
@@ -290,7 +316,7 @@ impl SharpPOSO {
 
         // Get masking factors for x_i and y_i decomposition
         let xr_list: Vec<Scalar> = (0..N).map(|_| Scalar::random()).collect();
-        let yr_list: Vec<Scalar> = (0..3*N).map(|_| Scalar::random()).collect();
+        let yr_list: Vec<Scalar> = (0..3 * N).map(|_| Scalar::random()).collect();
         let mu_r_list: Vec<Scalar> = (0..R).map(|_| Scalar::random()).collect();
 
         let mut d_list: Vec<Scalar> = vec![];
@@ -298,17 +324,16 @@ impl SharpPOSO {
             let mut sum = Scalar::new(&SCALAR_ZERO);
 
             for i in 0..N {
-
                 // x_i == y_i0, therefore xr_i == yr_i0
-                let gamma_index = k*N*4 + i*4;
+                let gamma_index = k * N * 4 + i * 4;
                 let gamma_i0k = gamma_list[gamma_index as usize];
                 let yr_i0 = xr_list[i as usize];
                 sum += &(yr_i0 * &gamma_i0k);
 
                 for j in 0..3 {
-                    let gamma_index = k*N*4 + i*4 + j + 1;
+                    let gamma_index = k * N * 4 + i * 4 + j + 1;
                     let gamma_ijk = gamma_list[gamma_index as usize];
-                    let yr_ij = yr_list[(i*3 + j) as usize];
+                    let yr_ij = yr_list[(i * 3 + j) as usize];
                     sum += &(yr_ij * &gamma_ijk);
                 }
             }
@@ -316,14 +341,20 @@ impl SharpPOSO {
             let d_k = sum + &mu_r_list[k as usize];
             d_list.push(d_k);
         }
-        
+
         // Set D_x_list = [r_x_0 * G_blind + xr_i * G_amount, ...]
         // Set D_y = rr_y * G_blind + 𝜮{i=1 to N} 𝜮{j=1 to 3} yr_{i,j} * G_{i,j} + 𝜮{k=1 to R} mu_r_k * G_k
-        let D_x: Vec<GroupElement> = (0..N).map(|i| GENERATORS.G_blind * &rr_x_list[i as usize] + &(GENERATORS.G_amount * &xr_list[i as usize])).collect();
+        let D_x: Vec<GroupElement> = (0..N)
+            .map(|i| {
+                GENERATORS.G_blind * &rr_x_list[i as usize]
+                    + &(GENERATORS.G_amount * &xr_list[i as usize])
+            })
+            .collect();
         let mut D_y = GENERATORS.G_blind * &rr_y;
-        for i in 1..N+1 {
+        for i in 1..N + 1 {
             for j in 0..3 {
-                D_y += &(rast_3dec_generators[(i*3+j) as usize] * &yr_list[(i*4+j+1) as usize]);
+                D_y += &(rast_3dec_generators[(i * 3 + j) as usize]
+                    * &yr_list[(i * 4 + j + 1) as usize]);
             }
         }
         for k in 0..R {
@@ -347,41 +378,48 @@ impl SharpPOSO {
         for i in 0..N {
             // alpha_*_1_i = 4·B·rr_x_i - 8·a_i·rr_x_i - 2𝜮 y_ij · yr_ij
             // alpha_*_0_i = -(4·xr_i^2 + 𝜮 yr_ij^2)
-            let mut alpha_star_1_i = xr_list[i as usize] * &scalar_4B - &(xr_list[i as usize] * &amount_attributes[i as usize].a * &scalar_8);
-            let mut alpha_star_0_i = -(scalar_4 * &xr_list[i as usize] * &xr_list[i as usize]);        
+            let mut alpha_star_1_i = xr_list[i as usize] * &scalar_4B
+                - &(xr_list[i as usize] * &amount_attributes[i as usize].a * &scalar_8);
+            let mut alpha_star_0_i = -(scalar_4 * &xr_list[i as usize] * &xr_list[i as usize]);
             let mut sigma_1: Scalar = Scalar::new(&SCALAR_ZERO);
             let mut sigma_2: Scalar = Scalar::new(&SCALAR_ZERO);
             for j in 1..4 {
-                sigma_1 += &(y_list[(i*4+j+1) as usize] * &yr_list[(i*4+j+1) as usize]);
-                sigma_2 += &(yr_list[(i*4+j+1) as usize] * &yr_list[(i*4+j+1) as usize]);
+                sigma_1 += &(y_list[(i * 4 + j + 1) as usize] * &yr_list[(i * 4 + j + 1) as usize]);
+                sigma_2 +=
+                    &(yr_list[(i * 4 + j + 1) as usize] * &yr_list[(i * 4 + j + 1) as usize]);
             }
             alpha_star_1_i += &(-sigma_1 * &scalar_2);
             alpha_star_0_i += &-sigma_2;
 
-            C_star += &(H_list[(i+1) as usize] * &alpha_star_1_i);
-            D_star += &(H_list[(i+1) as usize] * &alpha_star_0_i);   
+            C_star += &(H_list[(i + 1) as usize] * &alpha_star_1_i);
+            D_star += &(H_list[(i + 1) as usize] * &alpha_star_0_i);
         }
 
         // Prover sends (C*, {Dx_i}_1^N, Dy, D*, {d_k}_1^R) to verifier
         transcript.append_element(b"C_*", &C_star);
-        
+
         // Verifier responds with a challenge
         let gamma = transcript.get_challenge(b"gamma_large_chall");
 
         // t_y  = 𝜸 · r_y + rr_y
         let t_y = gamma * &r_y + &rr_y;
-        
+
         // t_x_i  = 𝜸 · r_x_i + rr_x_i
-        let t_x_list: Vec<Scalar> = (0..N).map(|i| gamma * &r_x_list[i as usize] + &rr_x_list[i as usize]).collect();
-        
+        let t_x_list: Vec<Scalar> = (0..N)
+            .map(|i| gamma * &r_x_list[i as usize] + &rr_x_list[i as usize])
+            .collect();
+
         // z_i = 𝜸 · x_i + xr_i
-        let z_x_list: Vec<Scalar> = (0..N).map(|i| gamma * &x_list[i as usize] + &xr_list[i as usize]).collect();
+        let z_x_list: Vec<Scalar> = (0..N)
+            .map(|i| gamma * &x_list[i as usize] + &xr_list[i as usize])
+            .collect();
 
         // z_i_j = 𝜸 · y_i_j + yr_i
         let mut z_y_list: Vec<Scalar> = vec![];
         for i in 0..N {
             for j in 1..4 {
-                let z_ij = gamma * &y_list[(i*4+j) as usize] + &yr_list[(i*3+j-1) as usize];
+                let z_ij =
+                    gamma * &y_list[(i * 4 + j) as usize] + &yr_list[(i * 3 + j - 1) as usize];
                 z_y_list.push(z_ij);
             }
         }
@@ -390,16 +428,23 @@ impl SharpPOSO {
         let t_star = gamma * &r_star + &rr_star;
 
         // 𝜏_k = 𝜸 · μ + μr
-        let tau_list: Vec<Scalar> = (0..R).map(|k| gamma * &mu_list[k as usize] + &mu_r_list[k as usize]).collect();
+        let tau_list: Vec<Scalar> = (0..R)
+            .map(|k| gamma * &mu_list[k as usize] + &mu_r_list[k as usize])
+            .collect();
 
         // Saving proof size by compressing {Dx, Dy, D*, d_}
         (0..N).for_each(|i| transcript.append_element(b"Dx", &D_x[i as usize]));
         transcript.append_element(b"Dy", &D_y);
         transcript.append_element(b"D*", &D_star);
-        (0..R).for_each(|k| transcript.append_element(b"d_k", &hash_to_curve(&d_list[k as usize].to_bytes()).unwrap()));
+        (0..R).for_each(|k| {
+            transcript.append_element(
+                b"d_k",
+                &hash_to_curve(&d_list[k as usize].to_bytes()).unwrap(),
+            )
+        });
 
         let d_h = transcript.get_challenge(b"D_h");
-        
+
         Ok(Self {
             C_y,
             zeta_list,
@@ -421,7 +466,7 @@ impl SharpPOSO {
         range_max: u64,
     ) -> bool {
         // MARK: - PARAMETERS SETUP
-        // We use the same group for short opening and decomposition   
+        // We use the same group for short opening and decomposition
         if amount_commitments.len() == 0 {
             return false;
         }
@@ -433,7 +478,7 @@ impl SharpPOSO {
         }
         let B = range_max;
         let P = BigInt::from_be_bytes(&CURVE_ORDER);
-        
+
         // Y is the challenge space size. For exact [0, B] membership, it must be Y < 4B
         let Y = BigInt::from(4 * B - 1);
         // R is the number of repetitions. It must be that (Y + 1)^R - 1 <= CURVE_ORDER
@@ -448,12 +493,12 @@ impl SharpPOSO {
         // L_x is the masking overhead for the short witnesses
         // 18((B·Y+1)·L_x)^2 ≤ SECP256K1_ORDER
         let mut L_x = BigInt::from(1);
-        tmp = (B*&Y+1) * &L_x;
+        tmp = (B * &Y + 1) * &L_x;
         tmp.pow(2);
         tmp *= 18;
         while tmp <= P {
             L_x <<= 1;
-            tmp = (B*&Y+1) * &L_x;
+            tmp = (B * &Y + 1) * &L_x;
             tmp.pow(2);
             tmp *= 18;
         }
@@ -473,33 +518,37 @@ impl SharpPOSO {
         let C_y = self.C_y;
 
         transcript.append_element(b"C_y", &C_y);
-        (0..4*N*R).for_each(|_| { transcript.get_challenge(b"short_chall"); });
-
+        (0..4 * N * R).for_each(|_| {
+            transcript.get_challenge(b"short_chall");
+        });
 
         // Get short challenges for every integer in the sq-decomp, for every x in the batch,
         // for every k in the repetitions R
-        let gamma_list: Vec<Scalar> = (0..4*N*R).map(|_| {
-            let big_chall = BigInt::from_be_bytes(&transcript.get_challenge(b"short_chall").to_bytes());
-            Scalar::try_from(&(big_chall % &Y)) // short chall
-        }
-        ).collect::<Result<Vec<Scalar>, Error>>().unwrap();
+        let gamma_list: Vec<Scalar> = (0..4 * N * R)
+            .map(|_| {
+                let big_chall =
+                    BigInt::from_be_bytes(&transcript.get_challenge(b"short_chall").to_bytes());
+                Scalar::try_from(&(big_chall % &Y)) // short chall
+            })
+            .collect::<Result<Vec<Scalar>, Error>>()
+            .unwrap();
 
         // Verify each 𝛇_k is short
         if (self.zeta_list.len() as u64) < R {
             return false;
         }
 
-        let upper_bound = 4*&N*&B*&Y;
+        let upper_bound = 4 * &N * &B * &Y;
         for zeta_k in self.zeta_list.iter() {
             // 𝛇_k ≤ (4·N·B·Y + 1)L_x
             if BigInt::from_be_bytes(&zeta_k.to_bytes()) > upper_bound {
                 return false;
-            } 
+            }
         }
 
         // Prover sends (C*, {Dx_i}_1^N, Dy, D*, {d_k}_1^R) to verifier
         transcript.append_element(b"C_*", &self.C_star);
-        
+
         // Verifier responds with a challenge
         let gamma = transcript.get_challenge(b"gamma_large_chall");
 
@@ -507,13 +556,14 @@ impl SharpPOSO {
         let mut Fx_list = vec![];
 
         // No surprises
-        if N != self.t_x_list.len() as u64 ||
-           N != self.z_x_list.len() as u64 {
-                return false;
-            }
+        if N != self.t_x_list.len() as u64 || N != self.z_x_list.len() as u64 {
+            return false;
+        }
 
         for i in 0..N {
-            let Fx_i = -amount_commitments[i as usize] * &gamma + &(GENERATORS.G_blind * &self.t_x_list[i as usize]) + &(GENERATORS.G_amount * &self.z_x_list[i as usize]);
+            let Fx_i = -amount_commitments[i as usize] * &gamma
+                + &(GENERATORS.G_blind * &self.t_x_list[i as usize])
+                + &(GENERATORS.G_amount * &self.z_x_list[i as usize]);
             Fx_list.push(Fx_i);
         }
 
@@ -522,7 +572,8 @@ impl SharpPOSO {
         let mut F_y = -self.C_y * &gamma + &(GENERATORS.G_blind * &self.t_y);
         for i in 0..N {
             for j in 0..3 {
-                F_y += &(generators_3dec[(i*3+j) as usize] * &self.z_y_list[(i*3+j) as usize]);
+                F_y +=
+                    &(generators_3dec[(i * 3 + j) as usize] * &self.z_y_list[(i * 3 + j) as usize]);
             }
         }
         for k in 0..R {
@@ -530,7 +581,7 @@ impl SharpPOSO {
         }
 
         // No surprises
-        if self.z_y_list.len() != (3*N) as usize {
+        if self.z_y_list.len() != (3 * N) as usize {
             return false;
         }
 
@@ -540,11 +591,11 @@ impl SharpPOSO {
             let mut f_k = -(self.zeta_list[k as usize] * &gamma);
             for i in 0..N {
                 // y_i0 = x_i0
-                f_k += &(self.z_x_list[i as usize] * &gamma_list[(k*N*4 + i*4) as usize]);
-
+                f_k += &(self.z_x_list[i as usize] * &gamma_list[(k * N * 4 + i * 4) as usize]);
 
                 for j in 0..3 {
-                    f_k += &(self.z_y_list[(i*3 + j) as usize] * &gamma_list[(k*N*4 + i*4 + j + 1) as usize]);
+                    f_k += &(self.z_y_list[(i * 3 + j) as usize]
+                        * &gamma_list[(k * N * 4 + i * 4 + j + 1) as usize]);
                 }
             }
 
@@ -553,18 +604,18 @@ impl SharpPOSO {
         }
 
         let mut f_star_list = vec![];
-        
+
         let scalar_4 = Scalar::from(4);
         let scalar_B = Scalar::from(B);
         let gamma_squared = gamma * &gamma;
-        
+
         // f_i* = 4·z_x_i·(𝜸B - z_x_i) + 𝜸^2 - 𝜮 z_y_ij^2
         for i in 0..N {
             let z_x_i = self.z_x_list[i as usize];
             let mut f_star_i = scalar_4 * &z_x_i * &(gamma * &scalar_B - &z_x_i) + &gamma_squared;
             for j in 0..3 {
-                let z_y_ij = self.z_y_list[(i*3+j) as usize];
-                f_star_i += &(-z_y_ij*&z_y_ij);
+                let z_y_ij = self.z_y_list[(i * 3 + j) as usize];
+                f_star_i += &(-z_y_ij * &z_y_ij);
             }
             f_star_list.push(f_star_i);
         }
@@ -574,14 +625,19 @@ impl SharpPOSO {
         // F* = -𝜸C* + t* · H0 + 𝜮 f_i* · H_i
         let mut F_star = -self.C_star * &gamma + &(H_list[0] * &self.t_star);
         for i in 0..N {
-            F_star += &(H_list[(i+1) as usize] * &f_star_list[i as usize]);
+            F_star += &(H_list[(i + 1) as usize] * &f_star_list[i as usize]);
         }
 
         // Verify we get the same value from shamir transform {Dx = Fx, Dy = Fy, D* = F*, d_k = f_k}
         (0..N).for_each(|i| transcript.append_element(b"Dx", &Fx_list[i as usize]));
         transcript.append_element(b"Dy", &F_y);
         transcript.append_element(b"D*", &F_star);
-        (0..R).for_each(|k| transcript.append_element(b"d_k", &hash_to_curve(&f_list[k as usize].to_bytes()).unwrap()));
+        (0..R).for_each(|k| {
+            transcript.append_element(
+                b"d_k",
+                &hash_to_curve(&f_list[k as usize].to_bytes()).unwrap(),
+            )
+        });
 
         let f_h = transcript.get_challenge(b"D_h");
 
@@ -601,22 +657,24 @@ mod tests {
     fn test_find_3_squares() {
         // sample values of the form 4*x + 1 (including small and larger ones)
         let samples: &[u64] = &[
-            1,      // 4*0+1
-            5,      // 4*1+1
-            9,      // 4*2+1
-            13,     // 4*3+1
-            21,     // 4*5+1
-            101,    // 4*25+1
-            1001,   // 4*250+1
-            4*12345 + 1,
-            4*1_000_000 + 1,
+            1,    // 4*0+1
+            5,    // 4*1+1
+            9,    // 4*2+1
+            13,   // 4*3+1
+            21,   // 4*5+1
+            101,  // 4*25+1
+            1001, // 4*250+1
+            4 * 12345 + 1,
+            4 * 1_000_000 + 1,
         ];
 
         for &n in samples {
             match find_3_squares(n) {
-                Ok((a,b,c)) => {
+                Ok((a, b, c)) => {
                     // ensure they are valid and sum correctly
-                    let sum = (a as u128)*(a as u128) + (b as u128)*(b as u128) + (c as u128)*(c as u128);
+                    let sum = (a as u128) * (a as u128)
+                        + (b as u128) * (b as u128)
+                        + (c as u128) * (c as u128);
                     assert_eq!(sum as u64, n, "Decomposition incorrect for n={}", n);
                 }
                 Err(err) => panic!("find_3_squares failed for n={} with error {:?}", n, err),

--- a/src/sharp.rs
+++ b/src/sharp.rs
@@ -12,19 +12,19 @@ use bitcoin::secp256k1::constants::CURVE_ORDER;
 use num_traits::Zero;
 
 /// Finds three squares that sum to a given value using Legendre's three-square theorem.
-/// 
+///
 /// This function implements a solution to represent a given positive integer as a sum of three squares,
 /// i.e., find x, y, z such that x² + y² + z² = value. The implementation uses Legendre's three-square
 /// theorem which states that a positive integer can be represented as a sum of three squares if and
 /// only if it is not of the form 4ᵃ(8b + 7).
-/// 
+///
 /// # Arguments
 /// * `value` - The positive integer to decompose into three squares
-/// 
+///
 /// # Returns
 /// * `Ok((x, y, z))` - A tuple of three non-negative integers whose squares sum to `value`
 /// * `Err(Error::ThreeSquaresFailure)` - If the value cannot be represented as sum of three squares
-/// 
+///
 /// # Examples
 /// ```
 /// let (x, y, z) = find_3_squares(21)?;
@@ -86,13 +86,13 @@ pub fn find_3_squares(value: u64) -> Result<(u64, u64, u64), Error> {
 }
 
 /// Generates a sequence of group elements for use in RAST 3-decomposition proof.
-/// 
+///
 /// # Arguments
 /// * `n` - The number of elements needed (will generate 3n generators)
-/// 
+///
 /// # Returns
 /// * `Vec<GroupElement>` - Vector of group elements used as generators
-/// 
+///
 /// This is an internal function used by the SharpPOSO proof system.
 fn get_rast_3dec_generators(n: u64) -> Vec<GroupElement> {
     (0..n * 3)
@@ -106,13 +106,13 @@ fn get_rast_3dec_generators(n: u64) -> Vec<GroupElement> {
 }
 
 /// Generates mask generators for the RAST 3-decomposition proof.
-/// 
+///
 /// # Arguments
 /// * `n` - The number of masks needed (will generate n+1 generators)
-/// 
+///
 /// # Returns
 /// * `Vec<GroupElement>` - Vector of group elements used as mask generators
-/// 
+///
 /// This is an internal function used by the SharpPOSO proof system.
 fn get_rast_3dec_masks_generators(n: u64) -> Vec<GroupElement> {
     (0..n + 1)
@@ -124,13 +124,13 @@ fn get_rast_3dec_masks_generators(n: u64) -> Vec<GroupElement> {
 }
 
 /// Generates generators for the second phase of the proof.
-/// 
+///
 /// # Arguments
 /// * `n` - The number of generators needed (will generate n+1 generators)
-/// 
+///
 /// # Returns
 /// * `Vec<GroupElement>` - Vector of group elements used as generators in phase 2
-/// 
+///
 /// This is an internal function used by the SharpPOSO proof system.
 fn get_generators_second_phase(n: u64) -> Vec<GroupElement> {
     (0..n + 1)
@@ -142,14 +142,14 @@ fn get_generators_second_phase(n: u64) -> Vec<GroupElement> {
 }
 
 /// Implementation of Short Relaxed Range Proofs (SharpPOSO).
-/// 
+///
 /// This struct implements the proof system described in the paper:
 /// "Short Relaxed Range Proofs" (https://eprint.iacr.org/2022/1153.pdf)
-/// 
+///
 /// The proof system allows proving that a committed value lies within a specific range [0, B]
 /// without revealing the actual value. This implementation supports batch proofs for multiple
 /// values simultaneously.
-/// 
+///
 /// The proof is split into two phases:
 /// 1. A phase for handling the range proof using three-square decomposition
 /// 2. A phase for proving the consistency of the decomposition
@@ -176,16 +176,16 @@ pub struct SharpPOSO {
 #[allow(non_snake_case)]
 impl SharpPOSO {
     /// Creates a new SharpPOSO proof for a batch of amount commitments.
-    /// 
+    ///
     /// # Arguments
     /// * `transcript` - A mutable reference to the Cashu transcript for the proof
     /// * `amount_attributes` - Slice of amount attributes to prove are in range
     /// * `range_max` - The upper bound B of the range [0, B] to prove
-    /// 
+    ///
     /// # Returns
     /// * `Ok(Self)` - A new SharpPOSO proof if successful
     /// * `Err(Error)` - If the proof creation fails
-    /// 
+    ///
     /// # Note
     /// The proof follows the algorithm described in Section 4 of the Short Relaxed Range Proofs paper.
     pub fn new(
@@ -533,17 +533,17 @@ impl SharpPOSO {
     }
 
     /// Verifies a SharpPOSO proof.
-    /// 
+    ///
     /// This method verifies that all committed amounts in the proof lie within the range [0, B].
-    /// 
+    ///
     /// # Arguments
     /// * `transcript` - A mutable reference to the Cashu transcript used in proof creation
     /// * `amount_commitments` - Slice of group elements representing the amount commitments
     /// * `range_max` - The upper bound B of the range [0, B] being proved
-    /// 
+    ///
     /// # Returns
     /// * `bool` - true if the proof verifies correctly, false otherwise
-    /// 
+    ///
     /// # Note
     /// The verification follows the algorithm described in Section 4 of the Short Relaxed Range Proofs paper.
     pub fn verify(

--- a/src/sharp.rs
+++ b/src/sharp.rs
@@ -3,7 +3,7 @@ use num_traits::FromBytes;
 
 use crate::{ errors::Error, generators::{hash_to_curve, GENERATORS}, models::AmountAttribute, secp::{GroupElement, Scalar, SCALAR_ZERO}, transcript::CashuTranscript
 };
-use bitcoin::{secp256k1::constants::CURVE_ORDER};
+use bitcoin::{amount, secp256k1::constants::CURVE_ORDER};
 
 pub fn find_3_squares(value: u64) -> Result<(u64, u64, u64), Error> {
     // Fast check using Legendre's three-square theorem:
@@ -58,13 +58,6 @@ fn get_rast_3dec_generators(n: u64) -> Vec<GroupElement> {
         let j = m % 3;
         let i = m / 3;
         hash_to_curve(format!("CASHU_SHARP_RAST_3DEC_{i}_{j}").as_bytes())
-                .expect("Couldn't map hash to point on the curve")
-    }).collect()
-}
-
-fn get_masks_generators(n: u64) -> Vec<GroupElement> {
-    (0..n+1).map(|m| {
-        hash_to_curve(format!("CASHU_SHARP_MASKS_{m}").as_bytes())
                 .expect("Couldn't map hash to point on the curve")
     }).collect()
 }
@@ -159,15 +152,14 @@ impl SharpPOSO {
 
         // MARK: - PHASE 1
 
-        // C_x is our aggregate commitment: C_x = 𝜮i r_i*G_blind + 𝜮i a_i*G_amount
-        // r_x = 𝜮i r_i*G_blind, so C_x = r_x*G_blind + 𝜮i a_i*G_amount
-        let mut C_x: GroupElement = GENERATORS.O;
-        let mut r_x: Scalar = Scalar::new(&SCALAR_ZERO);
-        for attribute in amount_attributes.iter() {
-            C_x = C_x + &attribute.commitment();
-            r_x = r_x + &attribute.r;
+        // A list with all the amount commitments C_x_i = [C_x_0, C_x_1, ...]
+        // A list with all the blinding factors r_x_i = [r_x_0, r_x_1, ...]
+        let mut C_x_list: Vec<GroupElement> = amount_attributes.iter().map(|att| att.commitment()).collect();
+        let mut r_x_list: Vec<Scalar> = amount_attributes.iter().map(|att| att.r).collect();
+        for C_x_i in C_x_list.iter() {
+            transcript.append_element(b"C_x_i", &C_x_i);
         }
-        transcript.append_element(b"C_x", &C_x);
+        
 
         // (Algorithm 2, Phase 1, line 1)
         // For each attribute's amount a_i, find y_(i,1), y_(i,2), y_(i,3)
@@ -175,9 +167,6 @@ impl SharpPOSO {
         let mut y_list: Vec<Scalar> = vec![];
         for attribute in amount_attributes.iter() {
             let a_i = u64::from(&attribute.a);
-            if a_i > B {
-                return Err(Error::OutOfRangeError)
-            }
             let v_i = 4 * a_i * (B - a_i) + 1;
             let (y_i1, y_i2, y_i3) = find_3_squares(v_i)?;
 
@@ -187,13 +176,12 @@ impl SharpPOSO {
 
         // (Algorithm 2, Phase 1, line 2)
         // We need to get generators and masking factors
-        let masks_generators = get_masks_generators(N);
         let rast_3dec_masks_generators = get_rast_3dec_masks_generators(R);
         let rast_3dec_generators = get_rast_3dec_generators(N);
         let r_y = Scalar::random();
 
 
-        let mut C_y = masks_generators[0] * &r_y;
+        let mut C_y = GENERATORS.G_blind * &r_y;
         for i in 0..N {
             let y_1 = y_list[(i*4+1) as usize];
             let y_2 = y_list[(i*4+2) as usize];
@@ -274,8 +262,11 @@ impl SharpPOSO {
 
         // MARK: - PHASE 2
 
-        // Get masking factors for r_x and r_y
-        let (rr_x, rr_y) = (Scalar::random(), Scalar::random());
+        // Get masking factor for r_y
+        let rr_y = Scalar::random();
+
+        // Get masking factors for amount masking factors (xr_list)
+        let rr_x_list = (0..N).map(|_| Scalar::random()).collect::<Vec<Scalar>>();
 
         // Get masking factors for x_i and y_i decomposition
         let xr_list: Vec<Scalar> = (0..N).map(|_| Scalar::random()).collect();
@@ -298,19 +289,63 @@ impl SharpPOSO {
             d_list.push(d_k);
         }
         
-        // Set D_x = r_x * G_0 + 𝜮{i=1 to N} x_i * G_i
-        // Set D_y = r_y * G_0 + 𝜮{i=1 to N} 𝜮{j=1 to 3} y_{i,j} * G_{i,j} + 𝜮{k=1 to R} mu_k * G_k
-        let mut D_x = masks_generators[0] * &rr_x;
-        let mut D_y = masks_generators[0] * &rr_y;
+        // Set D_x_list = [r_x_0 * G_blind + xr_i * G_amount, ...]
+        // Set D_y = rr_y * G_blind + 𝜮{i=1 to N} 𝜮{j=1 to 3} yr_{i,j} * G_{i,j} + 𝜮{k=1 to R} mu_r_k * G_k
+        let D_x: Vec<GroupElement> = (0..N).map(|i| GENERATORS.G_blind * &rr_x_list[i as usize] + &(GENERATORS.G_amount * &xr_list[i as usize])).collect();
+        let mut D_y = GENERATORS.G_blind * &rr_y;
         for i in 1..N+1 {
-            D_x = D_x + &(masks_generators[i as usize] * &xr_list[i as usize]);
             for j in 0..3 {
                 D_y = D_y + &(rast_3dec_generators[(i*3+j) as usize] * &yr_list[(i*4+j+1) as usize]);
-            } 
+            }
         }
         for k in 0..R {
             D_y = D_y + &(rast_3dec_masks_generators[k as usize] * &mu_r_list[k as usize]);
         }
+
+        let (r_star, rr_star) = (Scalar::random(), Scalar::random());
+
+        let mut alpha_star_0_list: Vec<Scalar> = vec![];
+        let mut alpha_star_1_list: Vec<Scalar> = vec![];
+        let scalar_4B = Scalar::from(4_u64) * &Scalar::from(B);
+        let scalar_8 = Scalar::from(8_u64);
+        let scalar_4 = Scalar::from(4_u64);
+        let scalar_2 = Scalar::from(2_u64);
+
+        let H_list = get_generators_second_phase(N);
+
+        // C* = r*H0 + 𝜮 𝛼(*)_1,i*Hi
+        // D* = rr*H0 + 𝜮 𝛼(*)_0,i*Hi
+        let mut C_star = H_list[0] * &r_star;
+        let mut D_star = H_list[0] * &rr_star;
+
+        for i in 0..N {
+            // alpha_*_1_i = 4*B*rr_x_i - 8*a_i*rr_x_i - 2𝜮 y_ij * yr_ij
+            // alpha_*_0_i = -(4xr_i^2 + 𝜮 yr_ij^2)
+            let mut alpha_star_1_i = xr_list[i as usize] * &scalar_4B - &(xr_list[i as usize] * &amount_attributes[i as usize].a * &scalar_8);
+            let mut alpha_star_0_i = -(scalar_4 * &xr_list[i as usize] * &xr_list[i as usize]);        
+            let mut sigma_1: Scalar = Scalar::new(&SCALAR_ZERO);
+            let mut sigma_2: Scalar = Scalar::new(&SCALAR_ZERO);
+            for j in 1..4 {
+                sigma_1 = sigma_1 + &(y_list[(i*4+j+1) as usize] * &yr_list[(i*4+j+1) as usize]);
+                sigma_2 = sigma_2 + &(yr_list[(i*4+j+1) as usize] * &yr_list[(i*4+j+1) as usize]);
+            }
+            alpha_star_1_i = alpha_star_1_i - &(scalar_2 * &sigma_1);
+            alpha_star_0_i = alpha_star_0_i - &sigma_2;
+
+            C_star = C_star + &(H_list[(i+1) as usize] * &alpha_star_1_i);
+            D_star = D_star + &(H_list[(i+1) as usize] * &alpha_star_0_i);   
+        }
+
+        // Prover sends (C*, {Dx_i}_1^N, Dy, D*, {d_k}_1^R) to verifier
+        transcript.append_element(b"C_*", &C_star);
+        let _ = D_x.iter().map(|D_x_i| transcript.append_element(b"D_x_i", &D_x_i));
+        transcript.append_element(b"D_y", &D_y);
+        transcript.append_element(b"D_*", &D_star);
+        let _ = d_list.iter().map(|d_k|
+            transcript.append_element(b"d_k", &hash_to_curve(&d_k.to_bytes()).expect("failed to map scalar to curve")));
+        
+        // Verifier responds with a challenge
+        let gamma = transcript.get_challenge(b"gamma_large_chall");
 
         Ok(Self {
 
@@ -320,7 +355,7 @@ impl SharpPOSO {
 
 #[cfg(test)]
 mod tests {
-    use super::*; // or crate::path::to::find_3_squares
+    use super::*;
 
     #[test]
     fn test_find_3_squares() {

--- a/src/sharp.rs
+++ b/src/sharp.rs
@@ -1,5 +1,4 @@
 use num_bigint::{BigInt, Sign};
-use num_traits::FromBytes;
 
 use crate::{
     errors::Error,
@@ -340,8 +339,13 @@ impl SharpPOSO {
             for k in 0..R {
                 let mut sum = Scalar::new(&SCALAR_ZERO);
                 for i in 0..N {
-                    for j in 0..4 {
-                        let gamma_index = k * N * 4 + i * 4 + j;
+                    let gamma_index = k * N * 4 + i * 4;
+                    let gamma_i0k = tmp_gamma_list[gamma_index as usize];
+                    let x_i = amount_attributes[i as usize].a;
+                    sum += &(x_i * &gamma_i0k);
+                    
+                    for j in 0..3 {
+                        let gamma_index = k * N * 4 + i * 4 + j + 1;
                         let gamma_ijk = tmp_gamma_list[gamma_index as usize];
                         let y_ij = y_list[(i * 3 + j) as usize];
                         sum += &(y_ij * &gamma_ijk);
@@ -426,10 +430,10 @@ impl SharpPOSO {
             })
             .collect();
         let mut D_y = GENERATORS.G_blind * &rr_y;
-        for i in 1..N + 1 {
+        for i in 0..N {
             for j in 0..3 {
                 D_y += &(rast_3dec_generators[(i * 3 + j) as usize]
-                    * &yr_list[(i * 4 + j + 1) as usize]);
+                    * &yr_list[(i * 3 + j) as usize]);
             }
         }
         for k in 0..R {
@@ -458,10 +462,10 @@ impl SharpPOSO {
             let mut alpha_star_0_i = -(scalar_4 * &xr_list[i as usize] * &xr_list[i as usize]);
             let mut sigma_1: Scalar = Scalar::new(&SCALAR_ZERO);
             let mut sigma_2: Scalar = Scalar::new(&SCALAR_ZERO);
-            for j in 1..4 {
-                sigma_1 += &(y_list[(i * 4 + j + 1) as usize] * &yr_list[(i * 4 + j + 1) as usize]);
+            for j in 0..3 {
+                sigma_1 += &(y_list[(i * 3 + j) as usize] * &yr_list[(i * 3 + j) as usize]);
                 sigma_2 +=
-                    &(yr_list[(i * 4 + j + 1) as usize] * &yr_list[(i * 4 + j + 1) as usize]);
+                    &(yr_list[(i * 3 + j) as usize] * &yr_list[(i * 3 + j) as usize]);
             }
             alpha_star_1_i += &(-sigma_1 * &scalar_2);
             alpha_star_0_i += &-sigma_2;
@@ -492,9 +496,9 @@ impl SharpPOSO {
         // z_i_j = 𝜸 · y_i_j + yr_i
         let mut z_y_list: Vec<Scalar> = vec![];
         for i in 0..N {
-            for j in 1..4 {
+            for j in 0..3 {
                 let z_ij =
-                    gamma * &y_list[(i * 4 + j) as usize] + &yr_list[(i * 3 + j - 1) as usize];
+                    gamma * &y_list[(i * 3 + j) as usize] + &yr_list[(i * 3 + j) as usize];
                 z_y_list.push(z_ij);
             }
         }

--- a/src/sharp.rs
+++ b/src/sharp.rs
@@ -77,7 +77,21 @@ fn get_generators_second_phase(n: u64) -> Vec<GroupElement> {
 }
 #[allow(non_snake_case)]
 pub struct SharpPOSO {
-    //pub C_x: GroupElement,
+    /// C_y
+    pub C_y: GroupElement,
+    /// 𝛇_k
+    pub zeta_list: Vec<Scalar>,
+    /// C*
+    pub C_star: GroupElement,
+    /// z_x_i for each x_i
+    pub z_x_list: Vec<Scalar>,
+    /// z_y_ij for each y_ij (3 squares of x_i)
+    pub z_y_list: Vec<Scalar>,
+    pub t_x_list: Vec<Scalar>,
+    pub t_y: Scalar,
+    pub t_star: Scalar,
+    pub tau_list: Vec<Scalar>,
+    pub d_h: Scalar,
 }
 
 // Paper: https://eprint.iacr.org/2022/1153.pdf
@@ -88,8 +102,8 @@ impl SharpPOSO {
         amount_attributes: &[AmountAttribute],
         range_max: u64,
     ) -> Result<Self, Error> {
-        // PARAMETER SETUP:
-        // We use the same group for proof of short opening and proof of decomposition   
+        // MARK: - PARAMETERS SETUP
+        // We use the same group for short opening and decomposition   
         if amount_attributes.len() == 0 {
             return Err(Error::EmptyList);
         }
@@ -114,7 +128,7 @@ impl SharpPOSO {
         R -= 1;
 
         // L_x is the masking overhead for the short witnesses
-        // We have that 18((BY+1)*L_x)^2 <= P must hold
+        // We have that 18((BY+1)*L_x)^2 <= SECP256K1_ORDER must hold
         let mut L_x = BigInt::from(1);
         tmp = (B*&Y+1) * &L_x;
         tmp.pow(2);
@@ -154,8 +168,9 @@ impl SharpPOSO {
 
         // A list with all the amount commitments C_x_i = [C_x_0, C_x_1, ...]
         // A list with all the blinding factors r_x_i = [r_x_0, r_x_1, ...]
-        let mut C_x_list: Vec<GroupElement> = amount_attributes.iter().map(|att| att.commitment()).collect();
-        let mut r_x_list: Vec<Scalar> = amount_attributes.iter().map(|att| att.r).collect();
+        let C_x_list: Vec<GroupElement> = amount_attributes.iter().map(|att| att.commitment()).collect();
+        let x_list: Vec<Scalar> = amount_attributes.iter().map(|att| att.a).collect();
+        let r_x_list: Vec<Scalar> = amount_attributes.iter().map(|att| att.r).collect();
         for C_x_i in C_x_list.iter() {
             transcript.append_element(b"C_x_i", &C_x_i);
         }
@@ -171,7 +186,7 @@ impl SharpPOSO {
             let (y_i1, y_i2, y_i3) = find_3_squares(v_i)?;
 
             // We insert a_i itself inside this tuple
-            y_list.extend_from_slice(&[Scalar::from(a_i), Scalar::from(y_i1), Scalar::from(y_i2), Scalar::from(y_i3)]);
+            y_list.extend_from_slice(&[Scalar::from(y_i1), Scalar::from(y_i2), Scalar::from(y_i3)]);
         }
 
         // (Algorithm 2, Phase 1, line 2)
@@ -183,12 +198,12 @@ impl SharpPOSO {
 
         let mut C_y = GENERATORS.G_blind * &r_y;
         for i in 0..N {
-            let y_1 = y_list[(i*4+1) as usize];
-            let y_2 = y_list[(i*4+2) as usize];
-            let y_3 = y_list[(i*4+3) as usize];
-            C_y = C_y + &(rast_3dec_generators[(3*i) as usize] * &y_1)
+            let y_1 = y_list[(i*3) as usize];
+            let y_2 = y_list[(i*3+1) as usize];
+            let y_3 = y_list[(i*3+2) as usize];
+            C_y += &((rast_3dec_generators[(3*i) as usize] * &y_1)
                 + &(rast_3dec_generators[(3*i+1) as usize] * &y_2)
-                + &(rast_3dec_generators[(3*i+2) as usize] * &y_3)
+                + &(rast_3dec_generators[(3*i+2) as usize] * &y_3))
         }
         let mu_list: Vec<Scalar>;
         let gamma_list: Vec<Scalar>;
@@ -228,7 +243,7 @@ impl SharpPOSO {
                         let gamma_index = k*N*4 + i*4 + j;
                         let gamma_ijk = tmp_gamma_list[gamma_index as usize];
                         let y_ij = y_list[(i*4 + j) as usize];
-                        sum = sum + &(y_ij * &gamma_ijk);
+                        sum += &(y_ij * &gamma_ijk);
                     }
                 }
                 // Try and mask the sum. If it fails we break out of the this for and set `too_big = true`
@@ -253,7 +268,7 @@ impl SharpPOSO {
             zeta_list = tmp_zeta_list;
 
             transcript.append_element(b"C_y", &C_y);
-            let _ = (0..4*N*R).map(|_| transcript.get_challenge(b"short_chall"));
+            (0..4*N*R).for_each(|_| { transcript.get_challenge(b"short_chall"); });
 
             break;
         }
@@ -270,18 +285,26 @@ impl SharpPOSO {
 
         // Get masking factors for x_i and y_i decomposition
         let xr_list: Vec<Scalar> = (0..N).map(|_| Scalar::random()).collect();
-        let yr_list: Vec<Scalar> = (0..4*N).map(|_| Scalar::random()).collect();
+        let yr_list: Vec<Scalar> = (0..3*N).map(|_| Scalar::random()).collect();
         let mu_r_list: Vec<Scalar> = (0..R).map(|_| Scalar::random()).collect();
 
         let mut d_list: Vec<Scalar> = vec![];
         for k in 0..R {
             let mut sum = Scalar::new(&SCALAR_ZERO);
+
             for i in 0..N {
-                for j in 0..4 {
-                    let gamma_index = k*N*4 + i*4 + j;
+
+                // x_i == y_i0, therefore xr_i == yr_i0
+                let gamma_index = k*N*4 + i*4;
+                let gamma_i0k = gamma_list[gamma_index as usize];
+                let yr_i0 = xr_list[i as usize];
+                sum += &(yr_i0 * &gamma_i0k);
+
+                for j in 0..3 {
+                    let gamma_index = k*N*4 + i*4 + j + 1;
                     let gamma_ijk = gamma_list[gamma_index as usize];
-                    let yr_ij = yr_list[(i*4 + j) as usize];
-                    sum = sum + &(yr_ij * &gamma_ijk);
+                    let yr_ij = yr_list[(i*3 + j) as usize];
+                    sum += &(yr_ij * &gamma_ijk);
                 }
             }
 
@@ -295,17 +318,15 @@ impl SharpPOSO {
         let mut D_y = GENERATORS.G_blind * &rr_y;
         for i in 1..N+1 {
             for j in 0..3 {
-                D_y = D_y + &(rast_3dec_generators[(i*3+j) as usize] * &yr_list[(i*4+j+1) as usize]);
+                D_y += &(rast_3dec_generators[(i*3+j) as usize] * &yr_list[(i*4+j+1) as usize]);
             }
         }
         for k in 0..R {
-            D_y = D_y + &(rast_3dec_masks_generators[k as usize] * &mu_r_list[k as usize]);
+            D_y += &(rast_3dec_masks_generators[k as usize] * &mu_r_list[k as usize]);
         }
 
         let (r_star, rr_star) = (Scalar::random(), Scalar::random());
 
-        let mut alpha_star_0_list: Vec<Scalar> = vec![];
-        let mut alpha_star_1_list: Vec<Scalar> = vec![];
         let scalar_4B = Scalar::from(4_u64) * &Scalar::from(B);
         let scalar_8 = Scalar::from(8_u64);
         let scalar_4 = Scalar::from(4_u64);
@@ -313,42 +334,83 @@ impl SharpPOSO {
 
         let H_list = get_generators_second_phase(N);
 
-        // C* = r*H0 + 𝜮 𝛼(*)_1,i*Hi
-        // D* = rr*H0 + 𝜮 𝛼(*)_0,i*Hi
+        // C* = r* · H0 + 𝜮 𝛼(*)_1,i·Hi
+        // D* = rr* · H0 + 𝜮 𝛼(*)_0,i·Hi
         let mut C_star = H_list[0] * &r_star;
         let mut D_star = H_list[0] * &rr_star;
 
         for i in 0..N {
-            // alpha_*_1_i = 4*B*rr_x_i - 8*a_i*rr_x_i - 2𝜮 y_ij * yr_ij
-            // alpha_*_0_i = -(4xr_i^2 + 𝜮 yr_ij^2)
+            // alpha_*_1_i = 4·B·rr_x_i - 8·a_i·rr_x_i - 2𝜮 y_ij · yr_ij
+            // alpha_*_0_i = -(4·xr_i^2 + 𝜮 yr_ij^2)
             let mut alpha_star_1_i = xr_list[i as usize] * &scalar_4B - &(xr_list[i as usize] * &amount_attributes[i as usize].a * &scalar_8);
             let mut alpha_star_0_i = -(scalar_4 * &xr_list[i as usize] * &xr_list[i as usize]);        
             let mut sigma_1: Scalar = Scalar::new(&SCALAR_ZERO);
             let mut sigma_2: Scalar = Scalar::new(&SCALAR_ZERO);
             for j in 1..4 {
-                sigma_1 = sigma_1 + &(y_list[(i*4+j+1) as usize] * &yr_list[(i*4+j+1) as usize]);
-                sigma_2 = sigma_2 + &(yr_list[(i*4+j+1) as usize] * &yr_list[(i*4+j+1) as usize]);
+                sigma_1 += &(y_list[(i*4+j+1) as usize] * &yr_list[(i*4+j+1) as usize]);
+                sigma_2 += &(yr_list[(i*4+j+1) as usize] * &yr_list[(i*4+j+1) as usize]);
             }
-            alpha_star_1_i = alpha_star_1_i - &(scalar_2 * &sigma_1);
-            alpha_star_0_i = alpha_star_0_i - &sigma_2;
+            alpha_star_1_i += &(-sigma_1 * &scalar_2);
+            alpha_star_0_i += &-sigma_2;
 
-            C_star = C_star + &(H_list[(i+1) as usize] * &alpha_star_1_i);
-            D_star = D_star + &(H_list[(i+1) as usize] * &alpha_star_0_i);   
+            C_star += &(H_list[(i+1) as usize] * &alpha_star_1_i);
+            D_star += &(H_list[(i+1) as usize] * &alpha_star_0_i);   
         }
 
         // Prover sends (C*, {Dx_i}_1^N, Dy, D*, {d_k}_1^R) to verifier
         transcript.append_element(b"C_*", &C_star);
-        let _ = D_x.iter().map(|D_x_i| transcript.append_element(b"D_x_i", &D_x_i));
+        D_x.iter().for_each(|D_x_i| transcript.append_element(b"D_x_i", &D_x_i));
         transcript.append_element(b"D_y", &D_y);
         transcript.append_element(b"D_*", &D_star);
-        let _ = d_list.iter().map(|d_k|
+        d_list.iter().for_each(|d_k|
             transcript.append_element(b"d_k", &hash_to_curve(&d_k.to_bytes()).expect("failed to map scalar to curve")));
         
         // Verifier responds with a challenge
         let gamma = transcript.get_challenge(b"gamma_large_chall");
 
-        Ok(Self {
+        // t_y  = 𝜸 · r_y + rr_y
+        let t_y = gamma * &r_y + &rr_y;
+        
+        // t_x_i  = 𝜸 · r_x_i + rr_x_i
+        let t_x_list: Vec<Scalar> = (0..N).map(|i| gamma * &r_x_list[i as usize] + &rr_x_list[i as usize]).collect();
+        
+        // z_i = 𝜸 · x_i + xr_i
+        let z_x_list: Vec<Scalar> = (0..N).map(|i| gamma * &x_list[i as usize] + &xr_list[i as usize]).collect();
 
+        // z_i_j = 𝜸 · y_i_j + yr_i
+        let mut z_y_list: Vec<Scalar> = vec![];
+        for i in 0..N {
+            for j in 1..4 {
+                let z_ij = gamma * &y_list[(i*4+j) as usize] + &yr_list[(i*3+j-1) as usize];
+                z_y_list.push(z_ij);
+            }
+        }
+
+        // t* = 𝜸 · r* + rr*
+        let t_star = gamma * &r_star + &rr_star;
+
+        // 𝜏_k = 𝜸 · μ + μr
+        let tau_list: Vec<Scalar> = (0..R).map(|k| gamma * &mu_list[k as usize] + &mu_r_list[k as usize]).collect();
+
+        // Saving proof size by compressing {Dx, Dy, D*, d_}
+        (0..N).for_each(|i| transcript.append_element(b"Dx", &D_x[i as usize]));
+        transcript.append_element(b"Dy", &D_y);
+        transcript.append_element(b"D*", &D_star);
+        (0..R).for_each(|k| transcript.append_element(b"d_k", &hash_to_curve(&d_list[k as usize].to_bytes()).unwrap()));
+
+        let d_h = transcript.get_challenge(b"D_h");
+        
+        Ok(Self {
+            C_y,
+            zeta_list,
+            C_star,
+            z_x_list,
+            z_y_list,
+            t_x_list,
+            t_y,
+            t_star,
+            tau_list,
+            d_h,
         })
     }
 }

--- a/src/sharp.rs
+++ b/src/sharp.rs
@@ -1,0 +1,315 @@
+use num_bigint::BigInt;
+use num_traits::FromBytes;
+
+use crate::{ errors::Error, generators::{hash_to_curve, GENERATORS}, models::AmountAttribute, secp::{GroupElement, Scalar, SCALAR_ZERO}, transcript::CashuTranscript
+};
+use bitcoin::{secp256k1::constants::CURVE_ORDER};
+use bitcoin::hashes::sha512_256::Hash as Sha512_256;
+use bitcoin::hashes::Hash;
+
+pub fn find_3_squares(value: u64) -> Result<(u64, u64, u64), Error> {
+    // Fast check using Legendre's three-square theorem:
+    // n is representable iff it's NOT of the form 4^a (8b+7).
+    fn is_excluded_by_legendre(mut n: u64) -> bool {
+        while n % 4 == 0 {
+            n /= 4;
+        }
+        n % 8 == 7
+    }
+
+    if value == 0 {
+        return Ok((0, 0, 0));
+    }
+    if is_excluded_by_legendre(value) {
+        return Err(Error::ThreeSquaresFailure);
+    }
+
+    // Try to find integers 0 <= x <= y <= z with x^2 + y^2 + z^2 = value.
+    // Iterate x from 0..=sqrt(value), then y from x..=sqrt(value - x^2),
+    // compute remaining rem = value - x^2 - y^2 and check if it's a perfect square.
+    let vmax = (value as f64).sqrt() as u64;
+    for x in 0..=vmax {
+        let x2 = (x as u128) * (x as u128);
+        if x2 > value as u128 { break; }
+        let rem1 = value as u128 - x2;
+        let ymax = (rem1 as f64).sqrt() as u64;
+        for y in x..=ymax {
+            let y2 = (y as u128) * (y as u128);
+            if y2 > rem1 { break; }
+            let rem2 = rem1 - y2;
+            // check if rem2 is a perfect square
+            let z = (rem2 as f64).sqrt() as u64;
+            for candidate_z in z..=z+1 {
+                let z2 = (candidate_z as u128) * (candidate_z as u128);
+                if z2 == rem2 {
+                    // return sorted tuple (x,y,z) where x<=y<=z
+                    return Ok((x, y, candidate_z));
+                }
+                if z2 > rem2 { break; }
+            }
+        }
+    }
+
+    // In theory, Legendre check should have excluded impossible cases.
+    // If no decomposition found (shouldn't happen), return failure.
+    Err(Error::ThreeSquaresFailure)
+}
+
+fn get_rast_3dec_generators(n: u64) -> Vec<GroupElement> {
+    (0..n*3).map(|m| {
+        let j = m % 3;
+        let i = m / 3;
+        hash_to_curve(format!("CASHU_SHARP_RAST_3DEC_{i}_{j}").as_bytes())
+                .expect("Couldn't map hash to point on the curve")
+    }).collect()
+}
+
+fn get_masks_generators(n: u64) -> Vec<GroupElement> {
+    (0..n+1).map(|m| {
+        hash_to_curve(format!("CASHU_SHARP_MASKS_{m}").as_bytes())
+                .expect("Couldn't map hash to point on the curve")
+    }).collect()
+}
+
+fn get_rast_3dec_masks_generators(n: u64) -> Vec<GroupElement> {
+    (0..n+1).map(|m| {
+        hash_to_curve(format!("CASHU_SHARP_RAST_3DEC_MASKS_{m}").as_bytes())
+                .expect("Couldn't map hash to point on the curve")
+    }).collect()
+}
+
+fn get_generators_second_phase(n: u64) -> Vec<GroupElement> {
+    (0..n+1).map(|m| {
+        hash_to_curve(format!("CASHU_SHARP_OPENINGS_{m}").as_bytes())
+                .expect("Couldn't map hash to point on the curve")
+    }).collect()
+}
+#[allow(non_snake_case)]
+pub struct SharpPOSO {
+    //pub C_x: GroupElement,
+}
+
+// Paper: https://eprint.iacr.org/2022/1153.pdf
+#[allow(non_snake_case)]
+impl SharpPOSO {
+    pub fn new(
+        transcript: &mut CashuTranscript,
+        amount_attributes: &[AmountAttribute],
+        range_max: u64,
+    ) -> Result<Self, Error> {
+        // PARAMETER SETUP:
+        // We use the same group for proof of short opening and proof of decomposition   
+        if amount_attributes.len() == 0 {
+            return Err(Error::EmptyList);
+        }
+        // N is the number of attributes to prove the range of
+        let N = amount_attributes.len() as u64;
+
+        if range_max == 0 {
+            return Err(Error::InvalidRangeBound)
+        }
+        let B = range_max;
+        let P = BigInt::from_be_bytes(&CURVE_ORDER);
+        
+        // Y is the challenge space size. For exact [0, B] membership, it must be Y < 4B
+        let Y = BigInt::from(4 * B - 1);
+        // R is the number of repetitions. It must be that (Y + 1)^R - 1 <= CURVE_ORDER
+        let mut R = 1;
+        let mut tmp: BigInt = &Y + 1;
+        while &tmp - 1 <= P {
+            R += 1;
+            tmp *= &Y + 1;
+        }
+        R -= 1;
+
+        // L_x is the masking overhead for the short witnesses
+        // We have that 18((BY+1)*L_x)^2 <= P must hold
+        let mut L_x = BigInt::from(1);
+        tmp = (B*&Y+1) * &L_x;
+        tmp.pow(2);
+        tmp *= 18;
+        while tmp <= P {
+            L_x <<= 1;
+            tmp = (B*&Y+1) * &L_x;
+            tmp.pow(2);
+            tmp *= 18;
+        }
+        L_x >>= 1;
+
+        if L_x == BigInt::from(0) {
+            return Err(Error::ParameterSetupFailure)
+        }
+
+        let apply_mask = |value: Scalar, mask: Scalar, V: &BigInt, L: &BigInt| -> Result<Scalar, Error> {
+            let r = (BigInt::from_be_bytes(&mask.to_bytes())) % (((V + 1)*L) + 1);
+            let v = BigInt::from_be_bytes(&value.to_bytes());
+            let z = v + r;
+            if z > (((V + 1)*L) + 1) {
+                return Err(Error::MaskingFailure);
+            }
+            Ok(Scalar::try_from(&z)?)
+        };
+
+        let get_mask = |V: &BigInt, L: &BigInt| -> Result<Scalar, Error> {
+            let nonce = Scalar::random();
+            let r = (BigInt::from_be_bytes(&nonce.to_bytes())) % (((V + 1)*L) + 1);
+            Ok(Scalar::try_from(&r)?)
+        };
+
+        transcript.domain_sep(b"SharpPOSO_Statement_");
+
+
+        // MARK: - PHASE 1
+
+        // C_x is our aggregate commitment: C_x = 𝜮i r_i*G_blind + 𝜮i a_i*G_amount
+        // r_x = 𝜮i r_i*G_blind, so C_x = r_x*G_blind + 𝜮i a_i*G_amount
+        let mut C_x: GroupElement = GENERATORS.O;
+        let mut r_x: Scalar = Scalar::new(&SCALAR_ZERO);
+        for attribute in amount_attributes.iter() {
+            C_x = C_x + &attribute.commitment();
+            r_x = r_x + &attribute.r;
+        }
+        transcript.append_element(b"C_x", &C_x);
+
+        // (Algorithm 2, Phase 1, line 1)
+        // For each attribute's amount a_i, find y_(i,1), y_(i,2), y_(i,3)
+        // s.t. 4 * a_i(B - a_i) + 1 = 𝜮j y_(i,j)^2.
+        let mut y_list: Vec<Scalar> = vec![];
+        for attribute in amount_attributes.iter() {
+            let a_i = u64::from(&attribute.a);
+            if a_i > B {
+                return Err(Error::OutOfRangeError)
+            }
+            let v_i = 4 * a_i * (B - a_i) + 1;
+            let (y_i1, y_i2, y_i3) = find_3_squares(v_i)?;
+
+            // We insert a_i itself inside this tuple
+            y_list.extend_from_slice(&[Scalar::from(a_i), Scalar::from(y_i1), Scalar::from(y_i2), Scalar::from(y_i3)]);
+        }
+
+        // (Algorithm 2, Phase 1, line 2)
+        // We need to get generators and masking factors
+        let masks_generators = get_masks_generators(N);
+        let rast_3dec_masks_generators = get_rast_3dec_masks_generators(R);
+        let rast_3dec_generators = get_rast_3dec_generators(N);
+        let r_y = Scalar::random();
+
+
+        let mut C_y = masks_generators[0] * &r_y;
+        for i in 0..N {
+            let y_1 = y_list[(i*4+1) as usize];
+            let y_2 = y_list[(i*4+2) as usize];
+            let y_3 = y_list[(i*4+3) as usize];
+            C_y = C_y + &(rast_3dec_generators[(3*i) as usize] * &y_1)
+                + &(rast_3dec_generators[(3*i+1) as usize] * &y_2)
+                + &(rast_3dec_generators[(3*i+2) as usize] * &y_3)
+        }
+        let mut mu_list: Vec<Scalar>;
+        let mut gamma_list: Vec<Scalar>;
+        let mut zeta_list: Vec<Scalar>;
+        let R_x = 4*N*B*&Y;
+
+        // Masking can succeed with probability 1-1/(L+1), and (1-1/(L+1))^R over all R repetitions
+        // Therefore, we should be looking at the following probability of failure at iteration i of this loop:
+        // (1-(1-1/(L+1))^R)^i
+        loop {
+            // We carry out operations on a cloned transcript,
+            // so we don't write on the real one. If successful,
+            // apply the same operations to the real one.
+            let mut tmp_transcript = transcript.clone();
+            let mut tmp_C_y = C_y;
+
+            let mut tmp_mu_list: Vec<Scalar> = vec![];           
+            for i in 0..R {
+                let mu_k = get_mask(&R_x, &L_x)?;
+
+                tmp_C_y = tmp_C_y + &(rast_3dec_masks_generators[i as usize] * &mu_k);
+                tmp_mu_list.push(mu_k);
+            }
+            
+            tmp_transcript.append_element(b"C_y", &tmp_C_y);
+
+            // Get the challenges for every integer in the sq-decomp, for every x in the batch,
+            // for every k in the repetitions R
+            let tmp_gamma_list: Vec<Scalar> = (0..4*N*R).map(|_| tmp_transcript.get_challenge(b"short_chall")).collect();
+            
+            let mut shortness_failure = false;
+            let mut tmp_zeta_list: Vec<Scalar> = vec![];
+            for k in 0..R {
+                let mut sum = Scalar::new(&SCALAR_ZERO);
+                for i in 0..N {
+                    for j in 0..4 {
+                        let gamma_index = k*N*4 + i*4 + j;
+                        let gamma_ijk = tmp_gamma_list[gamma_index as usize];
+                        let y_ij = y_list[(i*4 + j) as usize];
+                        sum = sum + &(y_ij * &gamma_ijk);
+                    }
+                }
+                // Try and mask the sum. If it fails we break out of the this for and set `too_big = true`
+                let masked_sum = apply_mask(sum, tmp_mu_list[k as usize], &R_x, &L_x);
+                match masked_sum {
+                    Ok(m) => tmp_zeta_list.push(m),
+                    Err(Error::MaskingFailure) => { shortness_failure = true; break; },
+                    Err(e) => return Err(e)
+                };
+            };
+
+            // If we get a masking failure, retry.
+            if shortness_failure {
+                continue;
+            }
+
+            // Otherwise, apply the changes to the trascript, C_y, mu_list and gamma_list.
+            // And break out of the loop
+            C_y = tmp_C_y;
+            mu_list = tmp_mu_list;
+            gamma_list = tmp_gamma_list;
+            zeta_list = tmp_zeta_list;
+
+            transcript.append_element(b"C_y", &C_y);
+            let _ = (0..4*N*R).map(|_| transcript.get_challenge(b"short_chall"));
+
+            break;
+        }
+        
+        // ### END PHASE 1 ###
+
+        // MARK: - PHASE 2
+
+        Ok(Self {
+
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*; // or crate::path::to::find_3_squares
+
+    #[test]
+    fn test_find_3_squares() {
+        // sample values of the form 4*x + 1 (including small and larger ones)
+        let samples: &[u64] = &[
+            1,      // 4*0+1
+            5,      // 4*1+1
+            9,      // 4*2+1
+            13,     // 4*3+1
+            21,     // 4*5+1
+            101,    // 4*25+1
+            1001,   // 4*250+1
+            4*12345 + 1,
+            4*1_000_000 + 1,
+        ];
+
+        for &n in samples {
+            match find_3_squares(n) {
+                Ok((a,b,c)) => {
+                    // ensure they are valid and sum correctly
+                    let sum = (a as u128)*(a as u128) + (b as u128)*(b as u128) + (c as u128)*(c as u128);
+                    assert_eq!(sum as u64, n, "Decomposition incorrect for n={}", n);
+                }
+                Err(err) => panic!("find_3_squares failed for n={} with error {:?}", n, err),
+            }
+        }
+    }
+}

--- a/src/sharp.rs
+++ b/src/sharp.rs
@@ -4,8 +4,6 @@ use num_traits::FromBytes;
 use crate::{ errors::Error, generators::{hash_to_curve, GENERATORS}, models::AmountAttribute, secp::{GroupElement, Scalar, SCALAR_ZERO}, transcript::CashuTranscript
 };
 use bitcoin::{secp256k1::constants::CURVE_ORDER};
-use bitcoin::hashes::sha512_256::Hash as Sha512_256;
-use bitcoin::hashes::Hash;
 
 pub fn find_3_squares(value: u64) -> Result<(u64, u64, u64), Error> {
     // Fast check using Legendre's three-square theorem:
@@ -204,9 +202,9 @@ impl SharpPOSO {
                 + &(rast_3dec_generators[(3*i+1) as usize] * &y_2)
                 + &(rast_3dec_generators[(3*i+2) as usize] * &y_3)
         }
-        let mut mu_list: Vec<Scalar>;
-        let mut gamma_list: Vec<Scalar>;
-        let mut zeta_list: Vec<Scalar>;
+        let mu_list: Vec<Scalar>;
+        let gamma_list: Vec<Scalar>;
+        let zeta_list: Vec<Scalar>;
         let R_x = 4*N*B*&Y;
 
         // Masking can succeed with probability 1-1/(L+1), and (1-1/(L+1))^R over all R repetitions
@@ -275,6 +273,44 @@ impl SharpPOSO {
         // ### END PHASE 1 ###
 
         // MARK: - PHASE 2
+
+        // Get masking factors for r_x and r_y
+        let (rr_x, rr_y) = (Scalar::random(), Scalar::random());
+
+        // Get masking factors for x_i and y_i decomposition
+        let xr_list: Vec<Scalar> = (0..N).map(|_| Scalar::random()).collect();
+        let yr_list: Vec<Scalar> = (0..4*N).map(|_| Scalar::random()).collect();
+        let mu_r_list: Vec<Scalar> = (0..R).map(|_| Scalar::random()).collect();
+
+        let mut d_list: Vec<Scalar> = vec![];
+        for k in 0..R {
+            let mut sum = Scalar::new(&SCALAR_ZERO);
+            for i in 0..N {
+                for j in 0..4 {
+                    let gamma_index = k*N*4 + i*4 + j;
+                    let gamma_ijk = gamma_list[gamma_index as usize];
+                    let yr_ij = yr_list[(i*4 + j) as usize];
+                    sum = sum + &(yr_ij * &gamma_ijk);
+                }
+            }
+
+            let d_k = sum + &mu_r_list[k as usize];
+            d_list.push(d_k);
+        }
+        
+        // Set D_x = r_x * G_0 + 𝜮{i=1 to N} x_i * G_i
+        // Set D_y = r_y * G_0 + 𝜮{i=1 to N} 𝜮{j=1 to 3} y_{i,j} * G_{i,j} + 𝜮{k=1 to R} mu_k * G_k
+        let mut D_x = masks_generators[0] * &rr_x;
+        let mut D_y = masks_generators[0] * &rr_y;
+        for i in 1..N+1 {
+            D_x = D_x + &(masks_generators[i as usize] * &xr_list[i as usize]);
+            for j in 0..3 {
+                D_y = D_y + &(rast_3dec_generators[(i*3+j) as usize] * &yr_list[(i*4+j+1) as usize]);
+            } 
+        }
+        for k in 0..R {
+            D_y = D_y + &(rast_3dec_masks_generators[k as usize] * &mu_r_list[k as usize]);
+        }
 
         Ok(Self {
 

--- a/src/sharp.rs
+++ b/src/sharp.rs
@@ -11,6 +11,26 @@ use crate::{
 use bitcoin::secp256k1::constants::CURVE_ORDER;
 use num_traits::Zero;
 
+/// Finds three squares that sum to a given value using Legendre's three-square theorem.
+/// 
+/// This function implements a solution to represent a given positive integer as a sum of three squares,
+/// i.e., find x, y, z such that x² + y² + z² = value. The implementation uses Legendre's three-square
+/// theorem which states that a positive integer can be represented as a sum of three squares if and
+/// only if it is not of the form 4ᵃ(8b + 7).
+/// 
+/// # Arguments
+/// * `value` - The positive integer to decompose into three squares
+/// 
+/// # Returns
+/// * `Ok((x, y, z))` - A tuple of three non-negative integers whose squares sum to `value`
+/// * `Err(Error::ThreeSquaresFailure)` - If the value cannot be represented as sum of three squares
+/// 
+/// # Examples
+/// ```
+/// let (x, y, z) = find_3_squares(21)?;
+/// assert_eq!(x*x + y*y + z*z, 21);
+/// ```
+///
 pub fn find_3_squares(value: u64) -> Result<(u64, u64, u64), Error> {
     // Fast check using Legendre's three-square theorem:
     // n is representable iff it's NOT of the form 4^a (8b+7).
@@ -65,6 +85,15 @@ pub fn find_3_squares(value: u64) -> Result<(u64, u64, u64), Error> {
     Err(Error::ThreeSquaresFailure)
 }
 
+/// Generates a sequence of group elements for use in RAST 3-decomposition proof.
+/// 
+/// # Arguments
+/// * `n` - The number of elements needed (will generate 3n generators)
+/// 
+/// # Returns
+/// * `Vec<GroupElement>` - Vector of group elements used as generators
+/// 
+/// This is an internal function used by the SharpPOSO proof system.
 fn get_rast_3dec_generators(n: u64) -> Vec<GroupElement> {
     (0..n * 3)
         .map(|m| {
@@ -76,6 +105,15 @@ fn get_rast_3dec_generators(n: u64) -> Vec<GroupElement> {
         .collect()
 }
 
+/// Generates mask generators for the RAST 3-decomposition proof.
+/// 
+/// # Arguments
+/// * `n` - The number of masks needed (will generate n+1 generators)
+/// 
+/// # Returns
+/// * `Vec<GroupElement>` - Vector of group elements used as mask generators
+/// 
+/// This is an internal function used by the SharpPOSO proof system.
 fn get_rast_3dec_masks_generators(n: u64) -> Vec<GroupElement> {
     (0..n + 1)
         .map(|m| {
@@ -85,6 +123,15 @@ fn get_rast_3dec_masks_generators(n: u64) -> Vec<GroupElement> {
         .collect()
 }
 
+/// Generates generators for the second phase of the proof.
+/// 
+/// # Arguments
+/// * `n` - The number of generators needed (will generate n+1 generators)
+/// 
+/// # Returns
+/// * `Vec<GroupElement>` - Vector of group elements used as generators in phase 2
+/// 
+/// This is an internal function used by the SharpPOSO proof system.
 fn get_generators_second_phase(n: u64) -> Vec<GroupElement> {
     (0..n + 1)
         .map(|m| {
@@ -93,6 +140,19 @@ fn get_generators_second_phase(n: u64) -> Vec<GroupElement> {
         })
         .collect()
 }
+
+/// Implementation of Short Relaxed Range Proofs (SharpPOSO).
+/// 
+/// This struct implements the proof system described in the paper:
+/// "Short Relaxed Range Proofs" (https://eprint.iacr.org/2022/1153.pdf)
+/// 
+/// The proof system allows proving that a committed value lies within a specific range [0, B]
+/// without revealing the actual value. This implementation supports batch proofs for multiple
+/// values simultaneously.
+/// 
+/// The proof is split into two phases:
+/// 1. A phase for handling the range proof using three-square decomposition
+/// 2. A phase for proving the consistency of the decomposition
 #[allow(non_snake_case)]
 pub struct SharpPOSO {
     /// C_y
@@ -112,9 +172,22 @@ pub struct SharpPOSO {
     pub d_h: Scalar,
 }
 
-// Paper: https://eprint.iacr.org/2022/1153.pdf
+// Implementation based on "Short Relaxed Range Proofs" (https://eprint.iacr.org/2022/1153.pdf)
 #[allow(non_snake_case)]
 impl SharpPOSO {
+    /// Creates a new SharpPOSO proof for a batch of amount commitments.
+    /// 
+    /// # Arguments
+    /// * `transcript` - A mutable reference to the Cashu transcript for the proof
+    /// * `amount_attributes` - Slice of amount attributes to prove are in range
+    /// * `range_max` - The upper bound B of the range [0, B] to prove
+    /// 
+    /// # Returns
+    /// * `Ok(Self)` - A new SharpPOSO proof if successful
+    /// * `Err(Error)` - If the proof creation fails
+    /// 
+    /// # Note
+    /// The proof follows the algorithm described in Section 4 of the Short Relaxed Range Proofs paper.
     pub fn new(
         transcript: &mut CashuTranscript,
         amount_attributes: &[AmountAttribute],
@@ -459,6 +532,20 @@ impl SharpPOSO {
         })
     }
 
+    /// Verifies a SharpPOSO proof.
+    /// 
+    /// This method verifies that all committed amounts in the proof lie within the range [0, B].
+    /// 
+    /// # Arguments
+    /// * `transcript` - A mutable reference to the Cashu transcript used in proof creation
+    /// * `amount_commitments` - Slice of group elements representing the amount commitments
+    /// * `range_max` - The upper bound B of the range [0, B] being proved
+    /// 
+    /// # Returns
+    /// * `bool` - true if the proof verifies correctly, false otherwise
+    /// 
+    /// # Note
+    /// The verification follows the algorithm described in Section 4 of the Short Relaxed Range Proofs paper.
     pub fn verify(
         &self,
         transcript: &mut CashuTranscript,

--- a/src/sharp.rs
+++ b/src/sharp.rs
@@ -343,7 +343,7 @@ impl SharpPOSO {
                     for j in 0..4 {
                         let gamma_index = k * N * 4 + i * 4 + j;
                         let gamma_ijk = tmp_gamma_list[gamma_index as usize];
-                        let y_ij = y_list[(i * 4 + j) as usize];
+                        let y_ij = y_list[(i * 3 + j) as usize];
                         sum += &(y_ij * &gamma_ijk);
                     }
                 }

--- a/src/sharp.rs
+++ b/src/sharp.rs
@@ -1,4 +1,4 @@
-use num_bigint::BigInt;
+use num_bigint::{BigInt, Sign};
 use num_traits::FromBytes;
 
 use crate::{
@@ -205,7 +205,7 @@ impl SharpPOSO {
             return Err(Error::InvalidRangeBound);
         }
         let B = range_max;
-        let P = BigInt::from_be_bytes(&CURVE_ORDER);
+        let P = BigInt::from_bytes_be(Sign::Plus, &CURVE_ORDER);
 
         // Y is the challenge space size. For exact [0, B] membership, Y < 4B
         let Y = BigInt::from(4 * B - 1);
@@ -224,6 +224,8 @@ impl SharpPOSO {
         tmp = (B * &Y + 1) * &L_x;
         tmp.pow(2);
         tmp *= 18;
+        println!("tmp = {}", tmp);
+        println!("P = {}", P);
         while tmp <= P {
             L_x <<= 1;
             tmp = (B * &Y + 1) * &L_x;
@@ -238,8 +240,8 @@ impl SharpPOSO {
 
         let apply_mask =
             |value: Scalar, mask: Scalar, V: &BigInt, L: &BigInt| -> Result<Scalar, Error> {
-                let r = (BigInt::from_be_bytes(&mask.to_bytes())) % (((V + 1) * L) + 1);
-                let v = BigInt::from_be_bytes(&value.to_bytes());
+                let r = (BigInt::from_bytes_be(Sign::Plus, &mask.to_bytes())) % (((V + 1) * L) + 1);
+                let v = BigInt::from_bytes_be(Sign::Plus, &value.to_bytes());
                 let z = v + r;
                 if z > (((V + 1) * L) + 1) {
                     return Err(Error::MaskingFailure);
@@ -249,7 +251,7 @@ impl SharpPOSO {
 
         let get_mask = |V: &BigInt, L: &BigInt| -> Result<Scalar, Error> {
             let nonce = Scalar::random();
-            let r = (BigInt::from_be_bytes(&nonce.to_bytes())) % (((V + 1) * L) + 1);
+            let r = (BigInt::from_bytes_be(Sign::Plus, &nonce.to_bytes())) % (((V + 1) * L) + 1);
             Scalar::try_from(&r)
         };
 
@@ -326,7 +328,7 @@ impl SharpPOSO {
             // for every k in the repetitions R
             let tmp_gamma_list: Vec<Scalar> = (0..4 * N * R)
                 .map(|_| {
-                    let big_chall = BigInt::from_be_bytes(
+                    let big_chall = BigInt::from_bytes_be(Sign::Plus,
                         &tmp_transcript.get_challenge(b"short_chall").to_bytes(),
                     );
                     Scalar::try_from(&(big_chall % &Y)) // short chall
@@ -564,7 +566,7 @@ impl SharpPOSO {
             return false;
         }
         let B = range_max;
-        let P = BigInt::from_be_bytes(&CURVE_ORDER);
+        let P = BigInt::from_bytes_be(Sign::Plus, &CURVE_ORDER);
 
         // Y is the challenge space size. For exact [0, B] membership, it must be Y < 4B
         let Y = BigInt::from(4 * B - 1);
@@ -614,7 +616,7 @@ impl SharpPOSO {
         let gamma_list: Vec<Scalar> = (0..4 * N * R)
             .map(|_| {
                 let big_chall =
-                    BigInt::from_be_bytes(&transcript.get_challenge(b"short_chall").to_bytes());
+                    BigInt::from_bytes_be(Sign::Plus, &transcript.get_challenge(b"short_chall").to_bytes());
                 Scalar::try_from(&(big_chall % &Y)) // short chall
             })
             .collect::<Result<Vec<Scalar>, Error>>()
@@ -628,7 +630,7 @@ impl SharpPOSO {
         let upper_bound = 4 * N * B * Y;
         for zeta_k in self.zeta_list.iter() {
             // 𝛇_k ≤ (4·N·B·Y + 1)L_x
-            if BigInt::from_be_bytes(&zeta_k.to_bytes()) > upper_bound {
+            if BigInt::from_bytes_be(Sign::Plus, &zeta_k.to_bytes()) > upper_bound {
                 return false;
             }
         }
@@ -767,5 +769,23 @@ mod tests {
                 Err(err) => panic!("find_3_squares failed for n={} with error {:?}", n, err),
             }
         }
+    }
+
+    #[test]
+    fn test_proof_creation_verification_roundtrip() {
+        let mut cli_tscr = CashuTranscript::new();
+        let mut mint_tscr = CashuTranscript::new();
+
+        let attributes: Vec<AmountAttribute> = vec![
+            AmountAttribute::new(2, None),
+            AmountAttribute::new(1, None),
+            AmountAttribute::new(14, None),
+        ];
+        let mut attribute_commitments = Vec::new();
+        for attr in attributes.iter() {
+            attribute_commitments.push(attr.commitment());
+        }
+        let range_proof = SharpPOSO::new(&mut cli_tscr, &attributes, 1 << 32).expect("range proof should compute correctly: ");
+        assert!(range_proof.verify(&mut mint_tscr, &attribute_commitments, 1 << 32))
     }
 }

--- a/src/sharp.rs
+++ b/src/sharp.rs
@@ -4,6 +4,7 @@ use num_traits::FromBytes;
 use crate::{ errors::Error, generators::{hash_to_curve, GENERATORS}, models::AmountAttribute, secp::{GroupElement, Scalar, SCALAR_ZERO}, transcript::CashuTranscript
 };
 use bitcoin::{amount, secp256k1::constants::CURVE_ORDER};
+use num_traits::Zero;
 
 pub fn find_3_squares(value: u64) -> Result<(u64, u64, u64), Error> {
     // Fast check using Legendre's three-square theorem:
@@ -116,7 +117,7 @@ impl SharpPOSO {
         let B = range_max;
         let P = BigInt::from_be_bytes(&CURVE_ORDER);
         
-        // Y is the challenge space size. For exact [0, B] membership, it must be Y < 4B
+        // Y is the challenge space size. For exact [0, B] membership, Y < 4B
         let Y = BigInt::from(4 * B - 1);
         // R is the number of repetitions. It must be that (Y + 1)^R - 1 <= CURVE_ORDER
         let mut R = 1;
@@ -128,7 +129,7 @@ impl SharpPOSO {
         R -= 1;
 
         // L_x is the masking overhead for the short witnesses
-        // We have that 18((BY+1)*L_x)^2 <= SECP256K1_ORDER must hold
+        // 18((B·Y+1)·L_x)^2 ≤ SECP256K1_ORDER
         let mut L_x = BigInt::from(1);
         tmp = (B*&Y+1) * &L_x;
         tmp.pow(2);
@@ -141,7 +142,7 @@ impl SharpPOSO {
         }
         L_x >>= 1;
 
-        if L_x == BigInt::from(0) {
+        if L_x.is_zero() {
             return Err(Error::ParameterSetupFailure)
         }
 
@@ -224,15 +225,19 @@ impl SharpPOSO {
             for i in 0..R {
                 let mu_k = get_mask(&R_x, &L_x)?;
 
-                tmp_C_y = tmp_C_y + &(rast_3dec_masks_generators[i as usize] * &mu_k);
+                tmp_C_y += &(rast_3dec_masks_generators[i as usize] * &mu_k);
                 tmp_mu_list.push(mu_k);
             }
             
             tmp_transcript.append_element(b"C_y", &tmp_C_y);
 
-            // Get the challenges for every integer in the sq-decomp, for every x in the batch,
+            // Get short challenges for every integer in the sq-decomp, for every x in the batch,
             // for every k in the repetitions R
-            let tmp_gamma_list: Vec<Scalar> = (0..4*N*R).map(|_| tmp_transcript.get_challenge(b"short_chall")).collect();
+            let tmp_gamma_list: Vec<Scalar> = (0..4*N*R).map(|_| {
+                let big_chall = BigInt::from_be_bytes(&tmp_transcript.get_challenge(b"short_chall").to_bytes());
+                Scalar::try_from(&(big_chall % &Y)) // short chall
+            }
+            ).collect::<Result<Vec<Scalar>, Error>>()?;
             
             let mut shortness_failure = false;
             let mut tmp_zeta_list: Vec<Scalar> = vec![];
@@ -246,7 +251,7 @@ impl SharpPOSO {
                         sum += &(y_ij * &gamma_ijk);
                     }
                 }
-                // Try and mask the sum. If it fails we break out of the this for and set `too_big = true`
+                // Try and mask the sum. If it fails we break out of this for and set `too_big = true`
                 let masked_sum = apply_mask(sum, tmp_mu_list[k as usize], &R_x, &L_x);
                 match masked_sum {
                     Ok(m) => tmp_zeta_list.push(m),
@@ -359,11 +364,6 @@ impl SharpPOSO {
 
         // Prover sends (C*, {Dx_i}_1^N, Dy, D*, {d_k}_1^R) to verifier
         transcript.append_element(b"C_*", &C_star);
-        D_x.iter().for_each(|D_x_i| transcript.append_element(b"D_x_i", &D_x_i));
-        transcript.append_element(b"D_y", &D_y);
-        transcript.append_element(b"D_*", &D_star);
-        d_list.iter().for_each(|d_k|
-            transcript.append_element(b"d_k", &hash_to_curve(&d_k.to_bytes()).expect("failed to map scalar to curve")));
         
         // Verifier responds with a challenge
         let gamma = transcript.get_challenge(b"gamma_large_chall");
@@ -412,6 +412,184 @@ impl SharpPOSO {
             tau_list,
             d_h,
         })
+    }
+
+    pub fn verify(
+        &self,
+        transcript: &mut CashuTranscript,
+        amount_commitments: &[GroupElement],
+        range_max: u64,
+    ) -> bool {
+        // MARK: - PARAMETERS SETUP
+        // We use the same group for short opening and decomposition   
+        if amount_commitments.len() == 0 {
+            return false;
+        }
+        // N is the number of attributes to prove the range of
+        let N = amount_commitments.len() as u64;
+
+        if range_max == 0 {
+            return false;
+        }
+        let B = range_max;
+        let P = BigInt::from_be_bytes(&CURVE_ORDER);
+        
+        // Y is the challenge space size. For exact [0, B] membership, it must be Y < 4B
+        let Y = BigInt::from(4 * B - 1);
+        // R is the number of repetitions. It must be that (Y + 1)^R - 1 <= CURVE_ORDER
+        let mut R = 1;
+        let mut tmp: BigInt = &Y + 1;
+        while &tmp - 1 <= P {
+            R += 1;
+            tmp *= &Y + 1;
+        }
+        R -= 1;
+
+        // L_x is the masking overhead for the short witnesses
+        // 18((B·Y+1)·L_x)^2 ≤ SECP256K1_ORDER
+        let mut L_x = BigInt::from(1);
+        tmp = (B*&Y+1) * &L_x;
+        tmp.pow(2);
+        tmp *= 18;
+        while tmp <= P {
+            L_x <<= 1;
+            tmp = (B*&Y+1) * &L_x;
+            tmp.pow(2);
+            tmp *= 18;
+        }
+        L_x >>= 1;
+
+        if L_x == BigInt::from(0) {
+            return false;
+        }
+
+        transcript.domain_sep(b"SharpPOSO_Statement_");
+
+        for C_x_i in amount_commitments.iter() {
+            transcript.append_element(b"C_x_i", C_x_i);
+        }
+
+        // Extract C_y and get challenges
+        let C_y = self.C_y;
+
+        transcript.append_element(b"C_y", &C_y);
+        (0..4*N*R).for_each(|_| { transcript.get_challenge(b"short_chall"); });
+
+
+        // Get short challenges for every integer in the sq-decomp, for every x in the batch,
+        // for every k in the repetitions R
+        let gamma_list: Vec<Scalar> = (0..4*N*R).map(|_| {
+            let big_chall = BigInt::from_be_bytes(&transcript.get_challenge(b"short_chall").to_bytes());
+            Scalar::try_from(&(big_chall % &Y)) // short chall
+        }
+        ).collect::<Result<Vec<Scalar>, Error>>().unwrap();
+
+        // Verify each 𝛇_k is short
+        if (self.zeta_list.len() as u64) < R {
+            return false;
+        }
+
+        let upper_bound = 4*&N*&B*&Y;
+        for zeta_k in self.zeta_list.iter() {
+            // 𝛇_k ≤ (4·N·B·Y + 1)L_x
+            if BigInt::from_be_bytes(&zeta_k.to_bytes()) > upper_bound {
+                return false;
+            } 
+        }
+
+        // Prover sends (C*, {Dx_i}_1^N, Dy, D*, {d_k}_1^R) to verifier
+        transcript.append_element(b"C_*", &self.C_star);
+        
+        // Verifier responds with a challenge
+        let gamma = transcript.get_challenge(b"gamma_large_chall");
+
+        // Compute Fx_i = -𝜸·C_x_i + t_x_i·G_blind + z_x_i·G_amount
+        let mut Fx_list = vec![];
+
+        // No surprises
+        if N != self.t_x_list.len() as u64 ||
+           N != self.z_x_list.len() as u64 {
+                return false;
+            }
+
+        for i in 0..N {
+            let Fx_i = -amount_commitments[i as usize] * &gamma + &(GENERATORS.G_blind * &self.t_x_list[i as usize]) + &(GENERATORS.G_amount * &self.z_x_list[i as usize]);
+            Fx_list.push(Fx_i);
+        }
+
+        let generators_3dec = get_rast_3dec_generators(N);
+        let generators_3dec_masks = get_rast_3dec_masks_generators(R);
+        let mut F_y = -self.C_y * &gamma + &(GENERATORS.G_blind * &self.t_y);
+        for i in 0..N {
+            for j in 0..3 {
+                F_y += &(generators_3dec[(i*3+j) as usize] * &self.z_y_list[(i*3+j) as usize]);
+            }
+        }
+        for k in 0..R {
+            F_y += &(generators_3dec_masks[k as usize] * &self.tau_list[k as usize]);
+        }
+
+        // No surprises
+        if self.z_y_list.len() != (3*N) as usize {
+            return false;
+        }
+
+        // Verify the correctness of the short witnesses 𝛇_k
+        let mut f_list = vec![];
+        for k in 0..R {
+            let mut f_k = -(self.zeta_list[k as usize] * &gamma);
+            for i in 0..N {
+                // y_i0 = x_i0
+                f_k += &(self.z_x_list[i as usize] * &gamma_list[(k*N*4 + i*4) as usize]);
+
+
+                for j in 0..3 {
+                    f_k += &(self.z_y_list[(i*3 + j) as usize] * &gamma_list[(k*N*4 + i*4 + j + 1) as usize]);
+                }
+            }
+
+            f_k += &self.tau_list[k as usize];
+            f_list.push(f_k);
+        }
+
+        let mut f_star_list = vec![];
+        
+        let scalar_4 = Scalar::from(4);
+        let scalar_B = Scalar::from(B);
+        let gamma_squared = gamma * &gamma;
+        
+        // f_i* = 4·z_x_i·(𝜸B - z_x_i) + 𝜸^2 - 𝜮 z_y_ij^2
+        for i in 0..N {
+            let z_x_i = self.z_x_list[i as usize];
+            let mut f_star_i = scalar_4 * &z_x_i * &(gamma * &scalar_B - &z_x_i) + &gamma_squared;
+            for j in 0..3 {
+                let z_y_ij = self.z_y_list[(i*3+j) as usize];
+                f_star_i += &(-z_y_ij*&z_y_ij);
+            }
+            f_star_list.push(f_star_i);
+        }
+
+        let H_list = get_generators_second_phase(N);
+
+        // F* = -𝜸C* + t* · H0 + 𝜮 f_i* · H_i
+        let mut F_star = -self.C_star * &gamma + &(H_list[0] * &self.t_star);
+        for i in 0..N {
+            F_star += &(H_list[(i+1) as usize] * &f_star_list[i as usize]);
+        }
+
+        // Verify we get the same value from shamir transform {Dx = Fx, Dy = Fy, D* = F*, d_k = f_k}
+        (0..N).for_each(|i| transcript.append_element(b"Dx", &Fx_list[i as usize]));
+        transcript.append_element(b"Dy", &F_y);
+        transcript.append_element(b"D*", &F_star);
+        (0..R).for_each(|k| transcript.append_element(b"d_k", &hash_to_curve(&f_list[k as usize].to_bytes()).unwrap()));
+
+        let f_h = transcript.get_challenge(b"D_h");
+
+        if f_h.to_bytes() != self.d_h.to_bytes() {
+            return false;
+        }
+
+        true
     }
 }
 

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -5,6 +5,7 @@ use crate::secp::{GroupElement, Scalar};
 
 /// A wrapper around `merlin::Transcript` for Fiat-Shamir transformations.
 #[wasm_bindgen]
+#[derive(Clone)]
 pub struct CashuTranscript {
     inner: Transcript,
 }


### PR DESCRIPTION
Adds SHARP (**SH**ort Rel**A**xed **R**ange **P**roofs) as an alternative range proof construction.
Paper is [here](https://eprint.iacr.org/2022/1153.pdf).

Sharp achieve shorter proof size and 10x faster computation times (both verifier and prover) in the same `secp256k1` setting.

<!---
To prove $(x_1, x_2, \ldots, x_i)$ are in range $[0, B]$, sharp works as follows:
1. A 3-square decomposition is found for each $x_i$ s.t. $4 x_i(B - x_i)+1 = \sum_{j=1}^{3} y_{i,j}^2$. If $x_i \in [0, B]$, then $x_i(B - x_i) \geq 0$. Then because of [Legendre's three-square theorem](https://en.wikipedia.org/wiki/Legendre%27s_three-square_theorem), $(y_1, y_2, y_3)$ exist.
2. The prover commits to the terms in the decomposition: $C_y = r_y\cdot G_0 + \sum_{i=1}^{N} \sum_{j=1}^3 y_{i,j} \cdot G_{i,j} + \sum_{k=1}^{R} \mu_k \cdot \stackrel{˜}G_k$
3. The prover receives challenges and creates a response which has to pass a shortness test. This happens for $R$ different repetitions to strengthen the soundness guarantees:
--->